### PR TITLE
feat(builder-rsbuild): support Storybook change detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,5 +46,17 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@10.14.0"
+  "packageManager": "pnpm@10.14.0",
+  "pnpm": {
+    "overrides": {
+      "@storybook/addon-docs": "0.0.0-pr-34370-sha-b4eae34c",
+      "@storybook/addon-onboarding": "0.0.0-pr-34370-sha-b4eae34c",
+      "@storybook/core-webpack": "0.0.0-pr-34370-sha-b4eae34c",
+      "@storybook/html": "0.0.0-pr-34370-sha-b4eae34c",
+      "@storybook/react": "0.0.0-pr-34370-sha-b4eae34c",
+      "@storybook/vue3": "0.0.0-pr-34370-sha-b4eae34c",
+      "@storybook/web-components": "0.0.0-pr-34370-sha-b4eae34c",
+      "storybook": "0.0.0-pr-34370-sha-b4eae34c"
+    }
+  }
 }

--- a/packages/builder-rsbuild/package.json
+++ b/packages/builder-rsbuild/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^2.0.0-beta.4",
-    "@storybook/core-webpack": "10.3.1",
+    "@storybook/core-webpack": "0.0.0-pr-34370-sha-b4eae34c",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.0.0",
     "@types/pretty-hrtime": "^1.0.3",

--- a/packages/builder-rsbuild/src/build-module-graph.ts
+++ b/packages/builder-rsbuild/src/build-module-graph.ts
@@ -1,0 +1,96 @@
+import type { Rspack } from '@rsbuild/core'
+import type { ModuleGraph, ModuleNode } from './types'
+
+type CompilationLike = Pick<Rspack.Compilation, 'modules' | 'moduleGraph'>
+type RspackModule = Rspack.Module
+
+const getModuleFile = (module: RspackModule): string | undefined =>
+  module.nameForCondition()
+
+const getModuleType = (module: RspackModule): ModuleNode['type'] => {
+  if (module.type.startsWith('css')) {
+    return 'css'
+  }
+
+  if (module.type.startsWith('asset')) {
+    return 'asset'
+  }
+
+  return 'js'
+}
+
+export function buildModuleGraph(compilation: CompilationLike): ModuleGraph {
+  const moduleGraph: ModuleGraph = new Map()
+  const moduleNodeMap = new WeakMap<object, ModuleNode>()
+
+  const getOrCreateModuleNode = (
+    module: RspackModule | null | undefined,
+  ): ModuleNode | undefined => {
+    if (!module) {
+      return undefined
+    }
+
+    const file = getModuleFile(module)
+    if (!file) {
+      return undefined
+    }
+
+    const existingNode = moduleNodeMap.get(module)
+    if (existingNode) {
+      return existingNode
+    }
+
+    const moduleNode: ModuleNode = {
+      file,
+      type: getModuleType(module),
+      importers: new Set(),
+      importedModules: new Set(),
+    }
+    moduleNodeMap.set(module, moduleNode)
+
+    const moduleSet = moduleGraph.get(file) ?? new Set<ModuleNode>()
+    moduleSet.add(moduleNode)
+    moduleGraph.set(file, moduleSet)
+
+    return moduleNode
+  }
+
+  for (const module of compilation.modules) {
+    getOrCreateModuleNode(module)
+  }
+
+  for (const module of compilation.modules) {
+    const moduleNode = getOrCreateModuleNode(module)
+    if (!moduleNode) {
+      continue
+    }
+
+    for (const connection of compilation.moduleGraph.getIncomingConnections(
+      module,
+    )) {
+      const importerNode = getOrCreateModuleNode(connection.originModule)
+      if (importerNode) {
+        moduleNode.importers.add(importerNode)
+        importerNode.importedModules.add(moduleNode)
+      }
+    }
+  }
+
+  return moduleGraph
+}
+
+export function mergeModuleGraphs(graphs: ModuleGraph[]): ModuleGraph {
+  const mergedGraph: ModuleGraph = new Map()
+
+  for (const graph of graphs) {
+    for (const [file, nodes] of graph.entries()) {
+      const mergedNodes = mergedGraph.get(file) ?? new Set<ModuleNode>()
+      for (const node of nodes) {
+        mergedNodes.add(node)
+      }
+      mergedGraph.set(file, mergedNodes)
+    }
+  }
+
+  return mergedGraph
+}

--- a/packages/builder-rsbuild/src/index.ts
+++ b/packages/builder-rsbuild/src/index.ts
@@ -131,6 +131,10 @@ let server: RsbuildDevServer
 const moduleGraphListeners = new Set<(moduleGraph: ModuleGraph) => void>()
 
 const notifyModuleGraphListeners = (stats: StatsOrMultiStats) => {
+  if (!stats) {
+    return
+  }
+
   const moduleGraph = mergeModuleGraphs(
     'stats' in stats
       ? stats.stats.map((childStats) =>

--- a/packages/builder-rsbuild/src/index.ts
+++ b/packages/builder-rsbuild/src/index.ts
@@ -11,13 +11,14 @@ import type {
   Preset,
   StorybookConfigRaw,
 } from 'storybook/internal/types'
+import { buildModuleGraph, mergeModuleGraphs } from './build-module-graph'
 import { withStatsJsonCompat } from './chromatic-stats'
 import { overrideRsbuildLogger } from './logger'
 import rsbuildConfig, {
   type RsbuildBuilderOptions,
 } from './preview/iframe-rsbuild.config'
 import { applyReactShims } from './react-shims'
-import type { RsbuildBuilder } from './types'
+import type { ModuleGraph, RsbuildBuilder } from './types'
 
 export * from './preview/virtual-module-mapping'
 export * from './types'
@@ -127,9 +128,35 @@ export const getConfig: RsbuildBuilder['getConfig'] = async (options) => {
 }
 
 let server: RsbuildDevServer
+const moduleGraphListeners = new Set<(moduleGraph: ModuleGraph) => void>()
+
+const notifyModuleGraphListeners = (stats: StatsOrMultiStats) => {
+  const moduleGraph = mergeModuleGraphs(
+    'stats' in stats
+      ? stats.stats.map((childStats) =>
+          buildModuleGraph(childStats.compilation),
+        )
+      : [buildModuleGraph(stats.compilation)],
+  )
+
+  for (const listener of moduleGraphListeners) {
+    listener(moduleGraph)
+  }
+}
 
 export async function bail(): Promise<void> {
+  moduleGraphListeners.clear()
   return server?.close()
+}
+
+export const onModuleGraphChange: NonNullable<
+  RsbuildBuilder['onModuleGraphChange']
+> = (cb) => {
+  moduleGraphListeners.add(cb)
+
+  return () => {
+    moduleGraphListeners.delete(cb)
+  }
 }
 
 export const start: RsbuildBuilder['start'] = async ({
@@ -160,8 +187,16 @@ export const start: RsbuildBuilder['start'] = async ({
   const waitFirstCompileDone = new Promise<StatsOrMultiStats>((resolve) => {
     rsbuildBuild.onDevCompileDone(({ stats, isFirstCompile }) => {
       if (!isFirstCompile) {
+        if (moduleGraphListeners.size > 0) {
+          notifyModuleGraphListeners(stats)
+        }
         return
       }
+
+      if (moduleGraphListeners.size > 0) {
+        notifyModuleGraphListeners(stats)
+      }
+
       resolve(stats)
     })
   })

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -77,6 +77,9 @@ const storybookPaths: Record<string, string> = {
 
 export type RsbuildBuilderOptions = Options & {
   typescriptOptions: TypescriptOptions
+  features?: Options['features'] & {
+    changeDetection?: boolean
+  }
 }
 
 const matchesStoriesByPath = (

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -1,5 +1,5 @@
 import { createRequire } from 'node:module'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { RsbuildConfig, Rspack } from '@rsbuild/core'
 import { loadConfig, mergeRsbuildConfig } from '@rsbuild/core'
@@ -7,6 +7,7 @@ import { pluginTypeCheck } from '@rsbuild/plugin-type-check'
 // @ts-expect-error (I removed this on purpose, because it's incorrect)
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin'
 import { pluginHtmlMinifierTerser } from 'rsbuild-plugin-html-minifier-terser'
+import slash from 'slash'
 import {
   getBuilderOptions,
   isPreservingSymlinks,
@@ -76,6 +77,60 @@ const storybookPaths: Record<string, string> = {
 
 export type RsbuildBuilderOptions = Options & {
   typescriptOptions: TypescriptOptions
+}
+
+const matchesStoriesByPath = (
+  filePath: string,
+  workingDir: string,
+  stories: Awaited<ReturnType<typeof normalizeStories>>,
+) => {
+  const relativePath = slash(relative(workingDir, filePath))
+  const importPath = relativePath.startsWith('.')
+    ? relativePath
+    : `./${relativePath}`
+
+  return stories.some((specifier) => {
+    const matcher = new RegExp(specifier.importPathMatcher)
+    return matcher.test(importPath)
+  })
+}
+
+const mergeLazyCompilationTest = (
+  lazyCompilation: Rspack.Configuration['lazyCompilation'],
+  options: {
+    workingDir: string
+    stories: Awaited<ReturnType<typeof normalizeStories>>
+  },
+): Rspack.Configuration['lazyCompilation'] => {
+  if (lazyCompilation === false) {
+    return false
+  }
+
+  const existingOptions = lazyCompilation === true ? {} : lazyCompilation
+  const existingTest = existingOptions?.test
+
+  return {
+    ...(existingOptions ?? {}),
+    test: (module: Rspack.Module) => {
+      const filePath = module.nameForCondition()
+      if (
+        filePath &&
+        matchesStoriesByPath(filePath, options.workingDir, options.stories)
+      ) {
+        return false
+      }
+
+      if (!existingTest) {
+        return true
+      }
+
+      if (existingTest instanceof RegExp) {
+        return filePath ? existingTest.test(filePath) : false
+      }
+
+      return existingTest(module)
+    },
+  }
 }
 
 export default async (
@@ -164,6 +219,16 @@ export default async (
               entries: false,
             }
           : builderOptions.lazyCompilation
+
+      if (features?.changeDetection) {
+        lazyCompilationConfig = mergeLazyCompilationTest(
+          lazyCompilationConfig,
+          {
+            workingDir,
+            stories,
+          },
+        )
+      }
     }
   }
 

--- a/packages/builder-rsbuild/src/types.ts
+++ b/packages/builder-rsbuild/src/types.ts
@@ -24,7 +24,22 @@ export interface TypescriptOptions extends TypeScriptOptionsBase {
   checkOptions?: PluginTypeCheckerOptions
 }
 
-export type RsbuildBuilder = Builder<RsbuildConfig, RsbuildStats>
+export interface ModuleNode {
+  file: string
+  type: 'js' | 'css' | 'asset'
+  importers: Set<ModuleNode>
+  importedModules: Set<ModuleNode>
+}
+
+export type ModuleGraph = Map<ModuleNode['file'], Set<ModuleNode>>
+
+export type OnModuleGraphChange = (
+  cb: (moduleGraph: ModuleGraph) => void,
+) => () => void
+
+export type RsbuildBuilder = Builder<RsbuildConfig, RsbuildStats> & {
+  onModuleGraphChange?: OnModuleGraphChange
+}
 
 export type RsbuildFinal = (
   config: RsbuildConfig,

--- a/packages/builder-rsbuild/tests/build-module-graph.test.ts
+++ b/packages/builder-rsbuild/tests/build-module-graph.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from '@rstest/core'
+import { buildModuleGraph, mergeModuleGraphs } from '../src/build-module-graph'
+
+type FakeModule = {
+  type: string
+  nameForCondition: () => string | undefined
+}
+
+type FakeConnection = {
+  originModule: FakeModule | null
+  resolvedModule: FakeModule | null
+}
+
+const createModule = (
+  file: string | undefined,
+  type = 'javascript/auto',
+): FakeModule => ({
+  type,
+  nameForCondition: () => file,
+})
+
+const createCompilation = (
+  modules: FakeModule[],
+  connections: Array<{ from: FakeModule; to: FakeModule }>,
+) => {
+  const incoming = new Map<FakeModule, FakeConnection[]>()
+
+  for (const { from, to } of connections) {
+    const incomingConnections = incoming.get(to) ?? []
+    incomingConnections.push({ originModule: from, resolvedModule: to })
+    incoming.set(to, incomingConnections)
+  }
+
+  return {
+    modules: new Set(modules),
+    moduleGraph: {
+      getIncomingConnections: (module: FakeModule) =>
+        incoming.get(module) ?? [],
+      getOutgoingConnections: () => [],
+    },
+  }
+}
+
+describe('buildModuleGraph', () => {
+  it('builds reverse and forward file relationships from the rspack module graph', () => {
+    const story = createModule('/repo/src/Button.stories.tsx')
+    const component = createModule('/repo/src/Button.tsx')
+    const styles = createModule('/repo/src/Button.css', 'css/module')
+
+    const moduleGraph = buildModuleGraph(
+      createCompilation(
+        [story, component, styles],
+        [
+          { from: story, to: component },
+          { from: component, to: styles },
+        ],
+      ) as never,
+    )
+
+    const componentNode = Array.from(
+      moduleGraph.get('/repo/src/Button.tsx') ?? [],
+    )[0]
+    const stylesNode = Array.from(
+      moduleGraph.get('/repo/src/Button.css') ?? [],
+    )[0]
+    const storyNode = Array.from(
+      moduleGraph.get('/repo/src/Button.stories.tsx') ?? [],
+    )[0]
+
+    expect(componentNode?.type).toBe('js')
+    expect(stylesNode?.type).toBe('css')
+    expect(Array.from(componentNode?.importers ?? [])).toEqual([storyNode])
+    expect(Array.from(componentNode?.importedModules ?? [])).toEqual([
+      stylesNode,
+    ])
+  })
+
+  it('keeps multiple module identities for the same file', () => {
+    const client = createModule('/repo/src/shared.ts')
+    const server = createModule('/repo/src/shared.ts')
+
+    const moduleGraph = buildModuleGraph(
+      createCompilation([client, server], []) as never,
+    )
+
+    expect(moduleGraph.get('/repo/src/shared.ts')?.size).toBe(2)
+  })
+
+  it('skips modules that do not resolve to a file path', () => {
+    const story = createModule('/repo/src/Button.stories.tsx')
+    const virtual = createModule(undefined)
+
+    const moduleGraph = buildModuleGraph(
+      createCompilation(
+        [story, virtual],
+        [{ from: story, to: virtual }],
+      ) as never,
+    )
+
+    expect(moduleGraph.size).toBe(1)
+    expect(moduleGraph.get('/repo/src/Button.stories.tsx')?.size).toBe(1)
+  })
+
+  it('merges module graphs from multiple compilations', () => {
+    const a = buildModuleGraph(
+      createCompilation([createModule('/repo/src/A.ts')], []) as never,
+    )
+    const b = buildModuleGraph(
+      createCompilation([createModule('/repo/src/B.ts')], []) as never,
+    )
+
+    const merged = mergeModuleGraphs([a, b])
+
+    expect(merged.has('/repo/src/A.ts')).toBe(true)
+    expect(merged.has('/repo/src/B.ts')).toBe(true)
+  })
+})

--- a/packages/builder-rsbuild/tests/index.test.ts
+++ b/packages/builder-rsbuild/tests/index.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, rs } from '@rstest/core'
+import { bail, executor, onModuleGraphChange, start } from '../src/index'
+
+rs.mock('../src/react-shims', () => ({
+  applyReactShims: rs.fn(async (config: unknown) => config),
+}))
+
+type DevCompileDoneCallback = (params: {
+  stats: {
+    compilation: unknown
+  }
+  isFirstCompile: boolean
+}) => void
+
+const createModule = (file: string, type = 'javascript/auto') => ({
+  type,
+  nameForCondition: () => file,
+})
+
+const createCompilation = () => {
+  const story = createModule('/repo/src/Button.stories.tsx')
+  const component = createModule('/repo/src/Button.tsx')
+
+  return {
+    modules: new Set([story, component]),
+    moduleGraph: {
+      getIncomingConnections(module: typeof component) {
+        return module === component
+          ? [{ originModule: story, resolvedModule: component }]
+          : []
+      },
+      getOutgoingConnections(module: typeof component) {
+        return module === story
+          ? [{ originModule: story, resolvedModule: component }]
+          : []
+      },
+    },
+  }
+}
+
+const waitFor = async (predicate: () => boolean) => {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > 1_000) {
+      throw new Error('Timed out waiting for predicate')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+const createStartArgs = () => {
+  const presetValues = new Map<string, unknown>([
+    [
+      'core',
+      {
+        builder: {
+          name: 'storybook-builder-rsbuild',
+          options: {
+            addonDocs: {},
+            fsCache: false,
+            lazyCompilation: false,
+          },
+        },
+      },
+    ],
+    ['framework', {}],
+    ['frameworkOptions', { renderer: '@storybook/react' }],
+    ['env', {}],
+    ['logLevel', 'info'],
+    [
+      'previewMainTemplate',
+      '<!DOCTYPE html><html><head></head><body><div id="root"></div></body></html>',
+    ],
+    ['previewHead', ''],
+    ['previewBody', ''],
+    ['docs', {}],
+    ['entries', []],
+    [
+      'stories',
+      [
+        {
+          directory: './stories',
+          files: '*.stories.tsx',
+          titlePrefix: '',
+        },
+      ],
+    ],
+    ['previewAnnotations', []],
+    ['tags', {}],
+    ['build', { test: {} }],
+  ])
+
+  return {
+    startTime: process.hrtime(),
+    options: {
+      host: '127.0.0.1',
+      configType: 'DEVELOPMENT',
+      configDir: process.cwd(),
+      quiet: true,
+      outputDir: 'storybook-static',
+      packageJson: { version: '8.0.0-test' },
+      presets: {
+        apply: rs.fn(async (name: string, defaultValue?: unknown) => {
+          if (name === 'mdxLoaderOptions' || name === 'typescript') {
+            return defaultValue ?? {}
+          }
+
+          return presetValues.get(name) ?? defaultValue
+        }),
+      },
+      previewUrl: 'http://localhost:6006/iframe.html',
+      typescriptOptions: {
+        check: false,
+        skipCompiler: true,
+      },
+      features: {},
+      build: {},
+    } as never,
+    router: {
+      use: rs.fn(),
+    } as never,
+    server: {} as never,
+  }
+}
+
+describe('onModuleGraphChange', () => {
+  it('notifies listeners after dev recompiles and unsubscribes on bail', async () => {
+    const callbacks: DevCompileDoneCallback[] = []
+    const createDevServer = rs.fn(async () => ({
+      middlewares: {},
+      connectWebSocket: rs.fn(),
+      afterListen: rs.fn(async () => undefined),
+      close: rs.fn(async () => undefined),
+    }))
+
+    executor.get = rs.fn(async () => ({
+      createRsbuild: rs.fn(async () => ({
+        createDevServer,
+        onDevCompileDone: (cb: DevCompileDoneCallback) => {
+          callbacks.push(cb)
+        },
+      })),
+    }))
+
+    const listener = rs.fn()
+    onModuleGraphChange(listener)
+
+    const started = start(createStartArgs())
+    await waitFor(() => callbacks.length > 0)
+
+    callbacks[0]?.({
+      stats: { compilation: createCompilation() },
+      isFirstCompile: true,
+    })
+    await started
+    listener.mockClear()
+
+    callbacks[0]?.({
+      stats: { compilation: createCompilation() },
+      isFirstCompile: false,
+    })
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0]?.[0].has('/repo/src/Button.tsx')).toBe(true)
+
+    await bail()
+
+    callbacks[0]?.({
+      stats: { compilation: createCompilation() },
+      isFirstCompile: false,
+    })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('merges graphs from multi-stats payloads', async () => {
+    const callbacks: DevCompileDoneCallback[] = []
+    const createDevServer = rs.fn(async () => ({
+      middlewares: {},
+      connectWebSocket: rs.fn(),
+      afterListen: rs.fn(async () => undefined),
+      close: rs.fn(async () => undefined),
+    }))
+
+    executor.get = rs.fn(async () => ({
+      createRsbuild: rs.fn(async () => ({
+        createDevServer,
+        onDevCompileDone: (cb: DevCompileDoneCallback) => {
+          callbacks.push(cb)
+        },
+      })),
+    }))
+
+    const listener = rs.fn()
+    onModuleGraphChange(listener)
+
+    const started = start(createStartArgs())
+    await waitFor(() => callbacks.length > 0)
+
+    callbacks[0]?.({
+      stats: {
+        stats: [
+          { compilation: createCompilation() },
+          {
+            compilation: {
+              modules: new Set([createModule('/repo/src/Extra.tsx')]),
+              moduleGraph: {
+                getIncomingConnections() {
+                  return []
+                },
+                getOutgoingConnections() {
+                  return []
+                },
+              },
+            },
+          },
+        ],
+      },
+      isFirstCompile: true,
+    } as never)
+    await started
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0]?.[0].has('/repo/src/Button.tsx')).toBe(true)
+    expect(listener.mock.calls[0]?.[0].has('/repo/src/Extra.tsx')).toBe(true)
+
+    await bail()
+  })
+})

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -20,6 +20,8 @@ type LazyCompilationOption = Rspack.Configuration['lazyCompilation']
 
 const createOptions = (
   lazyCompilation: LazyCompilationOption | 'unset' = false,
+  changeDetection = false,
+  stories = storiesConfig,
 ) => {
   const builderCoreOptions: Record<string, unknown> = {
     rsbuildConfigPath: fixtureRsbuildConfig,
@@ -50,7 +52,7 @@ const createOptions = (
     ],
     ['docs', {}],
     ['entries', storybookEntries],
-    ['stories', storiesConfig],
+    ['stories', stories],
     ['tags', {}],
     ['build', { test: {} }],
     ['previewAnnotations', []],
@@ -88,7 +90,7 @@ const createOptions = (
       check: false,
       skipCompiler: true,
     },
-    features: {},
+    features: { changeDetection },
     cache,
     configDir: fixtureDir,
     build: {},
@@ -137,8 +139,10 @@ describe('iframe-rsbuild.config', () => {
 
   const runRspackTool = async (
     lazyCompilation: LazyCompilationOption | 'unset',
+    changeDetection = false,
+    stories = storiesConfig,
   ) => {
-    const { options } = createOptions(lazyCompilation)
+    const { options } = createOptions(lazyCompilation, changeDetection, stories)
     const config = await createIframeRsbuildConfig(
       options as RsbuildBuilderOptions,
     )
@@ -183,6 +187,71 @@ describe('iframe-rsbuild.config', () => {
   it('passes through lazyCompilation options object', async () => {
     const { rspackConfig } = await runRspackTool({ entries: true })
     expect(rspackConfig.lazyCompilation).toEqual({ entries: true })
+  })
+
+  it('excludes story modules from lazy compilation when changeDetection is enabled', async () => {
+    const { rspackConfig } = await runRspackTool('unset', true)
+
+    expect(rspackConfig.lazyCompilation).toEqual({
+      entries: false,
+      test: expect.any(Function),
+    })
+
+    expect(
+      rspackConfig.lazyCompilation.test({
+        nameForCondition: () =>
+          resolve(fixtureDir, 'stories/Button.stories.tsx'),
+      }),
+    ).toBe(false)
+    expect(
+      rspackConfig.lazyCompilation.test({
+        nameForCondition: () => resolve(fixtureDir, 'stories/Button.tsx'),
+      }),
+    ).toBe(true)
+  })
+
+  it('composes an existing lazyCompilation.test when changeDetection is enabled', async () => {
+    const existingTest = rs.fn(() => true)
+    const { rspackConfig } = await runRspackTool(
+      { entries: true, test: existingTest },
+      true,
+    )
+
+    expect(
+      rspackConfig.lazyCompilation.test({
+        nameForCondition: () =>
+          resolve(fixtureDir, 'stories/Button.stories.tsx'),
+      }),
+    ).toBe(false)
+    expect(existingTest).not.toHaveBeenCalled()
+
+    expect(
+      rspackConfig.lazyCompilation.test({
+        nameForCondition: () => resolve(fixtureDir, 'stories/Button.tsx'),
+      }),
+    ).toBe(true)
+    expect(existingTest).toHaveBeenCalledTimes(1)
+  })
+
+  it('matches story files outside the working directory when changeDetection is enabled', async () => {
+    const externalStory = resolve(
+      process.cwd(),
+      '../external/src/Button.stories.tsx',
+    )
+
+    const { rspackConfig } = await runRspackTool('unset', true, [
+      {
+        directory: '../../../../../external/src',
+        files: '*.stories.tsx',
+        titlePrefix: '',
+      },
+    ])
+
+    expect(
+      rspackConfig.lazyCompilation.test({
+        nameForCondition: () => externalStory,
+      }),
+    ).toBe(false)
   })
 
   it('appends raw query fallback rule for asset/source imports', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  storybook: 0.0.0-pr-34370-sha-b4eae34c
+  '@storybook/addon-docs': 0.0.0-pr-34370-sha-b4eae34c
+  '@storybook/addon-onboarding': 0.0.0-pr-34370-sha-b4eae34c
+  '@storybook/core-webpack': 0.0.0-pr-34370-sha-b4eae34c
+  '@storybook/html': 0.0.0-pr-34370-sha-b4eae34c
+  '@storybook/react': 0.0.0-pr-34370-sha-b4eae34c
+  '@storybook/vue3': 0.0.0-pr-34370-sha-b4eae34c
+  '@storybook/web-components': 0.0.0-pr-34370-sha-b4eae34c
+
 importers:
 
   .:
@@ -85,8 +95,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.1
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-builder-rsbuild:
         specifier: workspace:*
         version: link:../builder-rsbuild
@@ -106,8 +116,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.1
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-builder-rsbuild:
         specifier: workspace:*
         version: link:../builder-rsbuild
@@ -182,8 +192,8 @@ importers:
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
       '@storybook/core-webpack':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
@@ -203,11 +213,13 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/builder-rsbuild/compiled/@storybook/core-webpack: {}
 
   packages/framework-html:
     dependencies:
@@ -215,8 +227,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0(rollup@4.57.0)
       '@storybook/html':
-        specifier: ^10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       find-up:
         specifier: ^5.0.0
         version: 5.0.0
@@ -243,8 +255,8 @@ importers:
         specifier: ^1.20.6
         version: 1.20.6
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -255,8 +267,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0(rollup@4.57.0)
       '@storybook/react':
-        specifier: ^10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@storybook/react-docgen-typescript-plugin':
         specifier: ^1.0.1
         version: 1.0.1(typescript@5.9.3)(webpack@5.104.1)
@@ -301,8 +313,8 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -310,8 +322,8 @@ importers:
   packages/framework-react-native-web:
     dependencies:
       '@storybook/react':
-        specifier: ^10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       rsbuild-plugin-react-native-web:
         specifier: workspace:*
         version: link:../rsbuild-plugin-react-native-web
@@ -341,8 +353,8 @@ importers:
         specifier: ^0.21.2
         version: 0.21.2(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -350,8 +362,8 @@ importers:
   packages/framework-vue3:
     dependencies:
       '@storybook/vue3':
-        specifier: ^10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))
       storybook-builder-rsbuild:
         specifier: workspace:*
         version: link:../builder-rsbuild
@@ -369,8 +381,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.1
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -381,8 +393,8 @@ importers:
   packages/framework-web-components:
     dependencies:
       '@storybook/web-components':
-        specifier: ^10.3.1
-        version: 10.3.1(lit@3.3.2)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(lit@3.3.2)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       storybook-builder-rsbuild:
         specifier: workspace:*
         version: link:../builder-rsbuild
@@ -397,8 +409,8 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -430,7 +442,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -438,20 +450,20 @@ importers:
         specifier: 1.2.5
         version: 1.2.5(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0))(esbuild@0.27.0)(vue@3.5.27(typescript@5.9.3))
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/web-components':
-        specifier: 10.3.1
-        version: 10.3.1(lit@3.3.2)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(lit@3.3.2)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-web-components-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-web-components
@@ -490,14 +502,14 @@ importers:
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -511,8 +523,8 @@ importers:
         specifier: ^6.1.2
         version: 6.1.2
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-addon-modernjs:
         specifier: workspace:*
         version: link:../../packages/addon-modernjs
@@ -554,14 +566,14 @@ importers:
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.0.1)(core-js@3.48.0)
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -575,8 +587,8 @@ importers:
         specifier: ^6.1.2
         version: 6.1.2
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-addon-modernjs:
         specifier: workspace:*
         version: link:../../../packages/addon-modernjs
@@ -635,7 +647,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -643,14 +655,14 @@ importers:
         specifier: ^1.4.5
         version: 1.4.5(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0))
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@16.14.68)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@16.14.68)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -664,8 +676,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       storybook-react-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-react
@@ -687,7 +699,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -695,14 +707,14 @@ importers:
         specifier: ^1.4.5
         version: 1.4.5(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0))
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -713,8 +725,8 @@ importers:
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.27)
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-react-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-react
@@ -768,11 +780,11 @@ importers:
         specifier: ^1.4.5
         version: 1.4.5(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0))
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -789,8 +801,8 @@ importers:
         specifier: ^8.5.6
         version: 8.5.6
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-react-native-web-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-react-native-web
@@ -815,7 +827,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -826,17 +838,17 @@ importers:
         specifier: 3.0.1
         version: 3.0.1(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@storybook/test-runner':
         specifier: 0.24.3
-        version: 0.24.3(@swc/helpers@0.5.18)(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.0))(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.1)(typescript@5.9.3))
+        version: 0.24.3(@swc/helpers@0.5.18)(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.0))(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.1)(typescript@5.9.3))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -868,8 +880,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-react-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-react
@@ -888,7 +900,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -902,14 +914,14 @@ importers:
         specifier: ^0.19.4
         version: 0.19.4(typescript@5.9.3)
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -920,8 +932,8 @@ importers:
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.27)
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-addon-rslib:
         specifier: workspace:*
         version: link:../../packages/addon-rslib
@@ -943,7 +955,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@module-federation/enhanced':
         specifier: ^2.2.3
         version: 2.2.3(@rspack/core@2.0.0-beta.2(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
@@ -966,14 +978,14 @@ importers:
         specifier: ^0.19.4
         version: 0.19.4(typescript@5.9.3)
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -984,8 +996,8 @@ importers:
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.27)
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-addon-rslib:
         specifier: workspace:*
         version: link:../../packages/addon-rslib
@@ -1004,7 +1016,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -1018,14 +1030,14 @@ importers:
         specifier: ^0.19.4
         version: 0.19.4(typescript@5.9.3)
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/vue3':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -1033,8 +1045,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0))(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(vue@3.5.27(typescript@5.9.3))(yaml@2.8.2)
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-addon-rslib:
         specifier: workspace:*
         version: link:../../packages/addon-rslib
@@ -1077,7 +1089,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -1088,14 +1100,14 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(react-refresh@0.18.0)
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react':
-        specifier: 10.3.1
-        version: 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
@@ -1121,8 +1133,8 @@ importers:
         specifier: ^0.18.0
         version: 0.18.0
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook-react-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-react
@@ -1137,25 +1149,25 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/html':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-html-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-html
@@ -1171,7 +1183,7 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.0.1
-        version: 5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@rsbuild/core':
         specifier: ^2.0.0-beta.4
         version: 2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0)
@@ -1179,20 +1191,20 @@ importers:
         specifier: 1.2.5
         version: 1.2.5(@rsbuild/core@2.0.0-beta.4(@module-federation/runtime-tools@2.2.3(node-fetch@3.3.2))(core-js@3.48.0))(esbuild@0.27.0)(vue@3.5.27(typescript@5.9.3))
       '@storybook/addon-docs':
-        specifier: 10.3.1
-        version: 10.3.1(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/addon-onboarding':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/vue3':
-        specifier: 10.3.1
-        version: 10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.1
       storybook:
-        specifier: 10.3.1
-        version: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 0.0.0-pr-34370-sha-b4eae34c
+        version: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook-vue3-rsbuild:
         specifier: workspace:*
         version: link:../../packages/framework-vue3
@@ -2192,7 +2204,7 @@ packages:
     resolution: {integrity: sha512-v80QBwVd8W6acH5NtDgFlUevIBaMZAh1pYpBiB40tuNzS242NTHeQHBDGYwIAbWKDnt1qfjJpcpL6pj5kAr4LA==}
     engines: {node: '>=20.0.0', yarn: '>=1.22.18'}
     peerDependencies:
-      storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4630,27 +4642,27 @@ packages:
   '@storybook/addon-coverage@3.0.1':
     resolution: {integrity: sha512-dfl2r3NKFM61fHObd8TulrdXQyOz1ZCMfSTA1EVBWYrPYDM+45AjLHzvVMfF8s78KYATGTp7PWh/D4JMJOjJ7g==}
 
-  '@storybook/addon-docs@10.3.1':
-    resolution: {integrity: sha512-0FBhfMEg96QUmhdtks3rchktEEWF2hKcEsr3XluybBoBi4xAIw1vm+RJtL9Jm45ppTdg28LF7U+OeMx5LwkMzQ==}
+  '@storybook/addon-docs@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-PXcmstB4cd9rl7rFYQ/Ji1ZSrw3HF2Q4AZnzKyoyyq4B2Evl14YrOEHtcFvFammb9Nr3aN3BeBxJJ0lKoy/QsQ==}
     peerDependencies:
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
-  '@storybook/addon-onboarding@10.3.1':
-    resolution: {integrity: sha512-fXhkG0dPvsuwlOmK2eOmc0CYJXUeWV8hZWlnthkqGKrzUyqXx0YmM3VdnKwk0/OnOCp1zykDoMtnjnDqWW4saQ==}
+  '@storybook/addon-onboarding@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-ctLkBcUkdiSu41jrWr1xO/7zrNnGXJpCEhE07F3pfOZOTdo0wfJIj+elSo2MPVZgBhyJeA3SdoZ5vD+xWw4o4A==}
     peerDependencies:
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
-  '@storybook/core-webpack@10.3.1':
-    resolution: {integrity: sha512-SI+JApJHB2Pt7FZOfEQWnBHLb8sUZ/dKdofBKTeKljxzZzTPzdyXsW2MJgb2DMeE57y5Ta4MTk4r8pEFwp47Jw==}
+  '@storybook/core-webpack@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-MMpBERpAbanpPPFC1fClYTt2D0yE8XlQltdetVyrevEMI42G+zwqq+5kw24QUfua+PS4aFhKStDPJ++apGl8kQ==}
     peerDependencies:
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
-  '@storybook/csf-plugin@10.3.1':
-    resolution: {integrity: sha512-P1WUSoyueV+ULpNeip4eIjjDvOXDBQI4gaq/s1PdAg1Szz/0GhDPu/CXuwukgkmyHaJP3aVR3pHPvSfeLfMCrA==}
+  '@storybook/csf-plugin@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-bgo6o5ILUe/mCnrCSb+FjUy6kJKfdbpWjZPN71UmKd2Ib8EqRb6y9gkWFLgZgvJV+dx771hKZnBxVsSrAwp2Vg==}
     peerDependencies:
       esbuild: '*'
       rollup: '*'
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
       vite: '*'
       webpack: '*'
     peerDependenciesMeta:
@@ -4666,10 +4678,10 @@ packages:
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
-  '@storybook/html@10.3.1':
-    resolution: {integrity: sha512-dCOczBUVb7Xv0tK0FCiEDK2uJqIwjJ6o1PxSfQQtCX72KgMgc/pI9QC9jetMEtgw20bEXLnZGS/3rj0l1wTQQg==}
+  '@storybook/html@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-sZLTL/JB+CKqJwMcBIwV161zOhS0I1x1wHOH4cjbYjzWM9Mzyl6SwKAno/7xZwQytSHG8t98U8DC+W07wF9toA==}
     peerDependencies:
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
   '@storybook/icons@2.0.1':
     resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
@@ -4683,19 +4695,19 @@ packages:
       typescript: '>= 3.x'
       webpack: '>= 4'
 
-  '@storybook/react-dom-shim@10.3.1':
-    resolution: {integrity: sha512-X337d639Bw9ej8vIi29bxgRsHcrFHhux1gMSmDifYjBRhTUXE3/OeDtoEl6ZV5Pgc5BAabUF5L2cl0mb428BYQ==}
+  '@storybook/react-dom-shim@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-MhXc47Pc3ZoSmRV94RCnulXB7daiChy+4kmBSI3imj5K+d2799JehZ2IHA/xkZe/NA1dnkmeb5RAOJ5zifQPCQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
-  '@storybook/react@10.3.1':
-    resolution: {integrity: sha512-DoiOwfVG8VVIxA9JD3wz5lE30RTxwOnSHJJv4qdlCCiPIJWBGjxug9bqFxUZlqDkkbUzFLGDOBxYDp05Y66dbQ==}
+  '@storybook/react@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-dhzgWovBhDvL3jdODjZhEI3aZy23SuRSURyVQvVwCDN/6Jc3grO90bbcPvJ0tBOij71MyHVAL9rzDOAIVLnEUw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       typescript:
@@ -4706,19 +4718,19 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
-      storybook: ^0.0.0-0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
-  '@storybook/vue3@10.3.1':
-    resolution: {integrity: sha512-dN7zTx9SRmoWEHIKWyXIDYu3dS4g9aVwUzMLZ4J+IpDodrICP5zfR7X6OgXUw/G5CMFY2S17QeSrz+ZieOzMRA==}
+  '@storybook/vue3@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-Y51rhIz2UMH+h+CkEwQWweSpB+WtP7LsbePFbLdYhPjgcHa3ctZ5qqEUSV0Od+jA3pAb/gak2lrObAtbReKFFQ==}
     peerDependencies:
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
       vue: ^3.0.0
 
-  '@storybook/web-components@10.3.1':
-    resolution: {integrity: sha512-z6RA305EkFS/zru1tQFHFslh48QtYYi+moa/POgdvxwtexNe8hH8bXouPm56TE35eSxmzDXm1JHxL3lHeqTzXQ==}
+  '@storybook/web-components@0.0.0-pr-34370-sha-b4eae34c':
+    resolution: {integrity: sha512-qT7zGeqRRh8wn0usvepaJsy01vapemu0ePndNKOmizKdFpQgMx96PexadOMKLkiCXKmhMf6An2j0FsLYwHIzRg==}
     peerDependencies:
       lit: ^2.0.0 || ^3.0.0
-      storybook: ^10.3.1
+      storybook: 0.0.0-pr-34370-sha-b4eae34c
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -5384,6 +5396,9 @@ packages:
 
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -10987,8 +11002,8 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
-  storybook@10.3.1:
-    resolution: {integrity: sha512-i/CA1dUyVcF6cNL3tgPTQ/G6Evh6r3QdATuiiKObrA3QkEKmt3jrY+WeuQA7FCcmHk/vKabeliNrblaff8aY6Q==}
+  storybook@0.0.0-pr-34370-sha-b4eae34c:
+    resolution: {integrity: sha512-K2uefsAR23oMLjXiC4AlXyOCBlpSVhaUdaDlMyCb8Pcd2cH6s0WUOyAhWfMcVKdhxW0uNkCYT4Z+ASsBVghg/g==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -12978,37 +12993,37 @@ snapshots:
 
   '@bufbuild/protobuf@2.6.3': {}
 
-  '@chromatic-com/storybook@5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
+  '@chromatic-com/storybook@5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 13.3.4
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
 
-  '@chromatic-com/storybook@5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@chromatic-com/storybook@5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 13.3.4
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
 
-  '@chromatic-com/storybook@5.0.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@chromatic-com/storybook@5.0.1(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 13.3.4
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -17221,15 +17236,15 @@ snapshots:
       - supports-color
       - vite
 
-  '@storybook/addon-docs@10.3.1(@types/react@16.14.68)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/addon-docs@0.0.0-pr-34370-sha-b4eae34c(@types/react@16.14.68)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@16.14.68)(react@18.3.1)
-      '@storybook/csf-plugin': 10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+      '@storybook/csf-plugin': 0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -17238,15 +17253,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/addon-docs@0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/csf-plugin': 10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+      '@storybook/csf-plugin': 0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -17255,15 +17270,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))':
+  '@storybook/addon-docs@0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/csf-plugin': 10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
+      '@storybook/csf-plugin': 0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -17272,15 +17287,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.3.1(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/addon-docs@0.0.0-pr-34370-sha-b4eae34c(@types/react@18.3.27)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@storybook/csf-plugin': 10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+      '@storybook/csf-plugin': 0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -17289,15 +17304,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.3.1(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/addon-docs@0.0.0-pr-34370-sha-b4eae34c(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.10)(react@18.3.1)
-      '@storybook/csf-plugin': 10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+      '@storybook/csf-plugin': 0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -17306,15 +17321,15 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.3.1(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/addon-docs@0.0.0-pr-34370-sha-b4eae34c(@types/react@19.2.10)(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.10)(react@18.3.1)
-      '@storybook/csf-plugin': 10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
+      '@storybook/csf-plugin': 0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@storybook/react-dom-shim': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -17323,26 +17338,26 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-onboarding@10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
+  '@storybook/addon-onboarding@0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
 
-  '@storybook/addon-onboarding@10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-onboarding@0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-onboarding@10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/addon-onboarding@0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/core-webpack@10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/core-webpack@0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/csf-plugin@0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.0
@@ -17350,9 +17365,9 @@ snapshots:
       vite: 6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(esbuild@0.27.0)
 
-  '@storybook/csf-plugin@10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/csf-plugin@0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.0
@@ -17360,9 +17375,9 @@ snapshots:
       vite: 6.3.5(@types/node@22.19.1)(jiti@1.21.7)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(esbuild@0.27.0)
 
-  '@storybook/csf-plugin@10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))':
+  '@storybook/csf-plugin@0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.0
@@ -17370,9 +17385,9 @@ snapshots:
       vite: 6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(esbuild@0.27.0)
 
-  '@storybook/csf-plugin@10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/csf-plugin@0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.0
@@ -17380,9 +17395,9 @@ snapshots:
       vite: 6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
       webpack: 5.104.1(esbuild@0.27.0)
 
-  '@storybook/csf-plugin@10.3.1(esbuild@0.27.0)(rollup@4.57.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
+  '@storybook/csf-plugin@0.0.0-pr-34370-sha-b4eae34c(esbuild@0.27.0)(rollup@4.57.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.3.5(@types/node@22.19.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.30.2)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2))(webpack@5.104.1(esbuild@0.27.0))':
     dependencies:
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.5
     optionalDependencies:
       esbuild: 0.27.0
@@ -17392,10 +17407,10 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/html@10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/html@0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
   '@storybook/icons@2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
@@ -17427,59 +17442,59 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@10.3.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
+  '@storybook/react-dom-shim@0.0.0-pr-34370-sha-b4eae34c(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
     dependencies:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
 
-  '@storybook/react-dom-shim@10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
+  '@storybook/react-dom-shim@0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
 
-  '@storybook/react-dom-shim@10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/react-dom-shim@0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/react-dom-shim@10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/react-dom-shim@0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react@10.3.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(typescript@5.9.3)':
+  '@storybook/react@0.0.0-pr-34370-sha-b4eae34c(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0))
       react: 16.14.0
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 16.14.0(react@16.14.0)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react@10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react@0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-dom-shim': 0.0.0-pr-34370-sha-b4eae34c(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-docgen: 8.0.2
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.3(@swc/helpers@0.5.18)(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.0))(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.1)(typescript@5.9.3))':
+  '@storybook/test-runner@0.24.3(@swc/helpers@0.5.18)(@types/node@22.19.1)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.27.0))(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.18))(@types/node@22.19.1)(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/generator': 7.28.6
@@ -17501,7 +17516,7 @@ snapshots:
       playwright: 1.58.1
       playwright-core: 1.58.1
       rimraf: 3.0.2
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       uuid: 8.3.2
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -17513,27 +17528,27 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/vue3@10.3.1(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))':
+  '@storybook/vue3@0.0.0-pr-34370-sha-b4eae34c(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vue@3.5.27(typescript@5.9.3))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       type-fest: 2.19.0
       vue: 3.5.27(typescript@5.9.3)
       vue-component-type-helpers: 3.2.6
 
-  '@storybook/web-components@10.3.1(lit@3.3.2)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/web-components@0.0.0-pr-34370-sha-b4eae34c(lit@3.3.2)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@storybook/global': 5.0.0
       lit: 3.3.2
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
 
-  '@storybook/web-components@10.3.1(lit@3.3.2)(storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@storybook/web-components@0.0.0-pr-34370-sha-b4eae34c(lit@3.3.2)(storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
       lit: 3.3.2
-      storybook: 10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      storybook: 0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
 
@@ -18291,6 +18306,8 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
+
+  '@webcontainer/env@1.1.1': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -25450,7 +25467,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0):
+  storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
@@ -25458,6 +25475,7 @@ snapshots:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
       esbuild: 0.27.0
       open: 10.2.0
       recast: 0.23.11
@@ -25473,7 +25491,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -25481,6 +25499,7 @@ snapshots:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
       esbuild: 0.27.0
       open: 10.2.0
       recast: 0.23.11
@@ -25496,7 +25515,7 @@ snapshots:
       - react-dom
       - utf-8-validate
 
-  storybook@10.3.1(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  storybook@0.0.0-pr-34370-sha-b4eae34c(@testing-library/dom@10.4.0)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -25504,6 +25523,7 @@ snapshots:
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
       '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
       esbuild: 0.27.0
       open: 10.2.0
       recast: 0.23.11

--- a/sandboxes/react-18/.storybook/main.ts
+++ b/sandboxes/react-18/.storybook/main.ts
@@ -22,6 +22,9 @@ const config: StorybookConfig = {
     name: getAbsolutePath('storybook-react-rsbuild'),
     options: {},
   },
+  features: {
+    changeDetection: true,
+  },
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {


### PR DESCRIPTION
## Summary

This adds Storybook `changeDetection` support to `storybook-builder-rsbuild` without requiring any new Rspack API.

## What changed

- add `onModuleGraphChange(cb)` support to the builder
- convert `Rspack Compilation.moduleGraph` into Storybook's builder-agnostic `ModuleGraph`
- emit graph updates from `onDevCompileDone` for initial compile and rebuilds
- exclude story modules from `lazyCompilation` when `features.changeDetection` is enabled by composing `lazyCompilation.test`
- add regression tests for graph construction, listener lifecycle, multistats merge, and lazyCompilation matching

## Validation

- `pnpm exec rstest 'packages/builder-rsbuild/tests/build-module-graph.test.ts' 'packages/builder-rsbuild/tests/index.test.ts' 'packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts'`
- manual canary validation against `storybook@0.0.0-pr-34370-sha-b4eae34c`
  - modify and remove-from-graph scenarios produced `modified/affected` statuses in the Storybook UI
  - direct file deletion that causes compile failure does not continue to update statuses, which matches the current canary behavior

## Notes

- root `pnpm.overrides` and the `sandboxes/react-18` `features.changeDetection` flag are intentionally included on this preview branch to keep canary validation reproducible while debugging with Storybook maintainers
- these temporary canary/debugging changes should be cleaned up before merging to `main`
