### PR TITLE
fix(builder-rsbuild): repair mocker runtime injection

### DIFF
--- a/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
@@ -29,7 +29,8 @@ export class RspackInjectMockerRuntimePlugin {
 
   apply(compiler: Rspack.Compiler) {
     const HtmlPlugin = this.getHtmlPlugin(compiler)
-    if (!HtmlPlugin || typeof HtmlPlugin.getHooks !== 'function') {
+    const getHtmlHooks = HtmlPlugin?.getCompilationHooks ?? HtmlPlugin?.getHooks
+    if (typeof getHtmlHooks !== 'function') {
       compiler
         .getInfrastructureLogger(PLUGIN_NAME)
         .warn('HTML plugin is not available. Cannot inject mocker runtime.')
@@ -37,7 +38,7 @@ export class RspackInjectMockerRuntimePlugin {
     }
 
     compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
-      HtmlPlugin.getHooks(compilation).beforeAssetTagGeneration.tapAsync(
+      getHtmlHooks(compilation).beforeAssetTagGeneration.tapAsync(
         PLUGIN_NAME,
         (data, cb) => {
           try {

--- a/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
@@ -52,16 +52,19 @@ export class RspackInjectMockerRuntimePlugin {
               )
             }
 
-            // Emit and reference the runtime once per compilation. Re-emitting an
-            // identical asset on every rebuild triggers spurious rebuild loops in dev.
+            // Emit once per compilation, because re-emitting an identical asset triggers
+            // spurious rebuild loops in dev.
             // See https://github.com/storybookjs/storybook/pull/33169.
             if (!compilation.getAsset(runtimeAssetName)) {
               compilation.emitAsset(
                 runtimeAssetName,
                 new Sources.RawSource(runtimeScriptContent),
               )
-              data.assets.js.unshift(runtimeAssetName)
             }
+
+            // Reference it from every page though. This hook runs once per HTML page, each
+            // with its own asset list, and each page needs the runtime before its scripts.
+            data.assets.js.unshift(runtimeAssetName)
 
             cb(null, data)
           } catch (error) {

--- a/packages/builder-rsbuild/tests/fixtures/mock-plugin/__mocks__/mocked-module.js
+++ b/packages/builder-rsbuild/tests/fixtures/mock-plugin/__mocks__/mocked-module.js
@@ -1,0 +1,3 @@
+// Manual mock for ../mocked-module.js. Its presence means the plugin redirects straight here
+// instead of going through the automock loader.
+export const value = 'mocked'

--- a/packages/builder-rsbuild/tests/fixtures/mock-plugin/mocked-module.js
+++ b/packages/builder-rsbuild/tests/fixtures/mock-plugin/mocked-module.js
@@ -1,0 +1,3 @@
+// Resolution target for the sb.mock() call in preview-with-mock.ts. Kept as .js so that
+// require.resolve finds it the way it would find a real dependency.
+export const value = 'real'

--- a/packages/builder-rsbuild/tests/fixtures/mock-plugin/preview-with-mock.ts
+++ b/packages/builder-rsbuild/tests/fixtures/mock-plugin/preview-with-mock.ts
@@ -1,0 +1,5 @@
+import { sb } from 'storybook/test'
+
+sb.mock('./mocked-module')
+
+export default {}

--- a/packages/builder-rsbuild/tests/fixtures/mock-plugin/preview-without-mock.ts
+++ b/packages/builder-rsbuild/tests/fixtures/mock-plugin/preview-without-mock.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/packages/builder-rsbuild/tests/plugins/rspack-inject-mocker-runtime-plugin.test.ts
+++ b/packages/builder-rsbuild/tests/plugins/rspack-inject-mocker-runtime-plugin.test.ts
@@ -1,0 +1,170 @@
+import type { Rspack } from '@rsbuild/core'
+import { describe, expect, it } from '@rstest/core'
+import { RspackInjectMockerRuntimePlugin } from '../../src/plugins/rspack-inject-mocker-runtime-plugin'
+
+const RUNTIME_ASSET = 'mocker-runtime-injected.js'
+
+type HooksApi = 'getCompilationHooks' | 'getHooks' | 'neither'
+
+type TagData = { assets: { js: string[] } }
+
+/**
+ * Applies the plugin against a stub compiler whose HTML plugin exposes `api`, and returns handles
+ * on what the plugin did with it: whether it tapped the hook at all, what it emitted, and a way to
+ * run the hook once per HTML page.
+ *
+ * `getHtmlPlugin` locates the HTML plugin by constructor name, so the stubs have to be named after
+ * the real ones.
+ */
+function applyPlugin(api: HooksApi) {
+  const warnings: string[] = []
+  const emitted: string[] = []
+  const errors: unknown[] = []
+  let tagHook:
+    | ((data: TagData, cb: (error: unknown) => void) => void)
+    | undefined
+  let startCompilation: ((compilation: unknown) => void) | undefined
+
+  const hooks = {
+    beforeAssetTagGeneration: {
+      tapAsync: (_name: string, fn: typeof tagHook) => {
+        tagHook = fn
+      },
+    },
+  }
+
+  /**
+   * Builds a stand-in HTML plugin instance. The name matters because `getHtmlPlugin` finds the
+   * plugin by constructor name, and the hooks accessor has to sit on the constructor because that
+   * is where the plugin reads it from.
+   */
+  const createHtmlPlugin = (name: string, accessor?: HooksApi): object => {
+    const Plugin = class {}
+    Object.defineProperty(Plugin, 'name', { value: name })
+    if (accessor && accessor !== 'neither') {
+      Object.defineProperty(Plugin, accessor, { value: () => hooks })
+    }
+    return new Plugin()
+  }
+
+  let htmlPlugin: object
+  switch (api) {
+    case 'getCompilationHooks':
+      htmlPlugin = createHtmlPlugin('HtmlRspackPlugin', 'getCompilationHooks')
+      break
+    case 'getHooks':
+      htmlPlugin = createHtmlPlugin('HtmlWebpackPlugin', 'getHooks')
+      break
+    default:
+      htmlPlugin = createHtmlPlugin('HtmlRspackPlugin')
+  }
+
+  const assets = new Map<string, unknown>()
+  const compilation = {
+    getAsset: (name: string) => assets.get(name),
+    emitAsset: (name: string, source: unknown) => {
+      assets.set(name, source)
+      emitted.push(name)
+    },
+  }
+
+  const compiler = {
+    options: { plugins: [htmlPlugin] },
+    hooks: {
+      compilation: {
+        tap: (_name: string, fn: (compilation: unknown) => void) => {
+          startCompilation = fn
+        },
+      },
+    },
+    webpack: {
+      sources: {
+        RawSource: class {
+          constructor(public value: string) {}
+        },
+      },
+    },
+    getInfrastructureLogger: () => ({
+      info: () => {},
+      debug: () => {},
+      warn: (message: string) => warnings.push(message),
+    }),
+  } as unknown as Rspack.Compiler
+
+  new RspackInjectMockerRuntimePlugin().apply(compiler)
+  startCompilation?.(compilation)
+
+  /**
+   * Runs the tag hook for one HTML page, each of which arrives with its own asset list, and
+   * returns the scripts that page ended up referencing.
+   */
+  const renderPage = (): string[] => {
+    const data: TagData = { assets: { js: [] } }
+    tagHook?.(data, (error) => {
+      if (error) {
+        errors.push(error)
+      }
+    })
+    return data.assets.js
+  }
+
+  return {
+    renderPage,
+    emitted,
+    warnings,
+    errors,
+    tapped: () => tagHook !== undefined,
+  }
+}
+
+describe('RspackInjectMockerRuntimePlugin', () => {
+  describe('locating the html plugin hooks', () => {
+    // Rspack's native HtmlRspackPlugin only offers getCompilationHooks, so requiring getHooks
+    // meant the runtime was never injected there.
+    it('taps the hook when the plugin exposes getCompilationHooks', () => {
+      const { renderPage, warnings, errors } = applyPlugin(
+        'getCompilationHooks',
+      )
+
+      expect(renderPage()).toContain(RUNTIME_ASSET)
+      expect(warnings).toEqual([])
+      expect(errors).toEqual([])
+    })
+
+    it('taps the hook when the plugin only exposes the deprecated getHooks', () => {
+      const { renderPage, warnings, errors } = applyPlugin('getHooks')
+
+      expect(renderPage()).toContain(RUNTIME_ASSET)
+      expect(warnings).toEqual([])
+      expect(errors).toEqual([])
+    })
+
+    it('warns and taps nothing when the plugin offers neither', () => {
+      const { tapped, warnings } = applyPlugin('neither')
+
+      expect(tapped()).toBe(false)
+      expect(warnings).toEqual([
+        'HTML plugin is not available. Cannot inject mocker runtime.',
+      ])
+    })
+  })
+
+  // The asset is emitted once so that dev rebuilds do not loop on an identical asset, but each
+  // page owns its own asset list and needs the runtime ahead of its scripts.
+  it('references the runtime from every page while emitting it once', () => {
+    const { renderPage, emitted, errors } = applyPlugin('getCompilationHooks')
+
+    expect(renderPage()).toContain(RUNTIME_ASSET)
+    expect(renderPage()).toContain(RUNTIME_ASSET)
+    expect(emitted).toEqual([RUNTIME_ASSET])
+    expect(errors).toEqual([])
+  })
+
+  it('prepends the runtime ahead of the page scripts', () => {
+    const { renderPage } = applyPlugin('getCompilationHooks')
+
+    const data: string[] = renderPage()
+
+    expect(data[0]).toBe(RUNTIME_ASSET)
+  })
+})

--- a/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
+++ b/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
@@ -2,6 +2,7 @@ import { resolve } from 'node:path'
 import type { Rspack } from '@rsbuild/core'
 import { rspack } from '@rsbuild/core'
 import { describe, expect, it } from '@rstest/core'
+import { resolve as resolvePosix } from 'pathe'
 import { RspackMockPlugin } from '../../src/plugins/rspack-mock-plugin'
 
 // extractMockCalls sends telemetry when it finds mocks.
@@ -141,7 +142,7 @@ describe('RspackMockPlugin', () => {
     replaceResource(resource)
 
     expect(resource.request).toBe(
-      resolve(fixtureDir, '__mocks__/mocked-module.js'),
+      resolvePosix(fixtureDir, '__mocks__/mocked-module.js'),
     )
   })
 

--- a/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
+++ b/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
@@ -40,7 +40,7 @@ function applyPlugin(
   // Drives the mtime the plugin sees, standing in for the compiler's cached file system.
   let previewMtime = 1_000
 
-  const compiler = {
+  const compilerStub = {
     context: fixtureDir,
     inputFileSystem: {
       statSync: () => ({ mtime: new Date(previewMtime) }),
@@ -60,7 +60,11 @@ function applyPlugin(
         warn: (message: string) => warnMessages.push(message),
         debug: (message: string) => debugMessages.push(message),
       }) as unknown as InfrastructureLogger,
-  } satisfies Partial<Rspack.Compiler> as Rspack.Compiler
+  } satisfies Partial<Rspack.Compiler>
+
+  // `Rspack.Compiler` declares a private field, so it is nominally typed and no object literal
+  // can be asserted to it directly. The `satisfies` above is what type-checks the stub.
+  const compiler = compilerStub as unknown as Rspack.Compiler
 
   const OriginalPlugin = rspack.NormalModuleReplacementPlugin
   ;(rspack as any).NormalModuleReplacementPlugin = class {

--- a/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
+++ b/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
@@ -1,0 +1,174 @@
+import { resolve } from 'node:path'
+import type { Rspack } from '@rsbuild/core'
+import { rspack } from '@rsbuild/core'
+import { describe, expect, it } from '@rstest/core'
+import { RspackMockPlugin } from '../../src/plugins/rspack-mock-plugin'
+
+// extractMockCalls sends telemetry when it finds mocks.
+process.env.STORYBOOK_DISABLE_TELEMETRY = 'true'
+
+const fixtureDir = resolve(__dirname, '../fixtures/mock-plugin')
+
+interface Resource {
+  request: string
+  context: string
+}
+
+type InfrastructureLogger = ReturnType<
+  Rspack.Compiler['getInfrastructureLogger']
+>
+
+/**
+ * Applies the plugin against a stub compiler and returns handles on the parts under test: the
+ * callback given to NormalModuleReplacementPlugin, a trigger for the mock-map refresh that
+ * normally runs on beforeRun, and the debug messages the plugin logged.
+ *
+ * `debugMessages` is what distinguishes an early return from a completed resolution: the plugin
+ * only logs on a failed resolve, so an unresolvable request that produces no message proves the
+ * callback bailed out before attempting resolution at all.
+ */
+function applyPlugin(
+  previewConfig: 'preview-with-mock.ts' | 'preview-without-mock.ts',
+) {
+  const infoMessages: string[] = []
+  const debugMessages: string[] = []
+  const warnMessages: string[] = []
+  let replaceResource: ((resource: Resource) => void) | undefined
+  let refreshMocks: (() => void) | undefined
+
+  // Drives the mtime the plugin sees, standing in for the compiler's cached file system.
+  let previewMtime = 1_000
+
+  const compiler = {
+    context: fixtureDir,
+    inputFileSystem: {
+      statSync: () => ({ mtime: new Date(previewMtime) }),
+    } as unknown as Rspack.Compiler['inputFileSystem'],
+    hooks: {
+      beforeRun: {
+        tap: (_name: string, fn: () => void) => {
+          refreshMocks = fn
+        },
+      },
+      watchRun: { tap: () => {} },
+      afterCompile: { tap: () => {} },
+    } as unknown as Rspack.Compiler['hooks'],
+    getInfrastructureLogger: () =>
+      ({
+        info: (message: string) => infoMessages.push(message),
+        warn: (message: string) => warnMessages.push(message),
+        debug: (message: string) => debugMessages.push(message),
+      }) as unknown as InfrastructureLogger,
+  } satisfies Partial<Rspack.Compiler> as Rspack.Compiler
+
+  const OriginalPlugin = rspack.NormalModuleReplacementPlugin
+  ;(rspack as any).NormalModuleReplacementPlugin = class {
+    constructor(_test: RegExp, callback: (resource: Resource) => void) {
+      replaceResource = callback
+    }
+    apply() {}
+  }
+
+  try {
+    new RspackMockPlugin({
+      previewConfigPath: resolve(fixtureDir, previewConfig),
+    }).apply(compiler)
+  } finally {
+    ;(rspack as any).NormalModuleReplacementPlugin = OriginalPlugin
+  }
+
+  if (!replaceResource || !refreshMocks) {
+    throw new Error('plugin did not register its replacement callback')
+  }
+  const runUpdateMocks = refreshMocks
+
+  runUpdateMocks()
+
+  // A warning here means mock resolution itself failed, which would make every assertion below
+  // pass for the wrong reason.
+  if (warnMessages.length > 0) {
+    throw new Error(
+      `plugin warned while resolving mocks: ${warnMessages.join('; ')}`,
+    )
+  }
+
+  /**
+   * Runs another compilation, optionally after the preview config has been rewritten. The plugin
+   * logs once per rebuild of a non-empty map, so `rebuildCount` reports whether it re-extracted.
+   */
+  const recompile = (mtime = previewMtime) => {
+    previewMtime = mtime
+    runUpdateMocks()
+  }
+
+  return {
+    replaceResource,
+    recompile,
+    debugMessages,
+    rebuildCount: () => infoMessages.length,
+  }
+}
+
+describe('RspackMockPlugin', () => {
+  it('does not resolve anything when no mocks are declared', () => {
+    const { replaceResource, debugMessages } = applyPlugin(
+      'preview-without-mock.ts',
+    )
+    const resource = { request: './not-a-real-module', context: fixtureDir }
+
+    replaceResource(resource)
+
+    expect(resource.request).toBe('./not-a-real-module')
+    expect(debugMessages).toEqual([])
+  })
+
+  // `pathe` is a real dependency, so getIsExternal reports it as external and it takes the
+  // candidateSpecifiers path. This pins the outcome, not the shortcut: skipping the resolve is an
+  // optimisation, so removing it would leave this request untouched either way.
+  it('leaves bare specifiers that are not mocked alone', () => {
+    const { replaceResource } = applyPlugin('preview-with-mock.ts')
+    const resource = { request: 'pathe', context: fixtureDir }
+
+    replaceResource(resource)
+
+    expect(resource.request).toBe('pathe')
+  })
+
+  it('redirects a request that matches a declared mock', () => {
+    const { replaceResource } = applyPlugin('preview-with-mock.ts')
+    const resource = { request: './mocked-module', context: fixtureDir }
+
+    replaceResource(resource)
+
+    expect(resource.request).toBe(
+      resolve(fixtureDir, '__mocks__/mocked-module.js'),
+    )
+  })
+
+  describe('mock map caching', () => {
+    it('reuses the map while the preview config mtime is unchanged', () => {
+      const { recompile, rebuildCount } = applyPlugin('preview-with-mock.ts')
+
+      recompile()
+
+      expect(rebuildCount()).toBe(1)
+    })
+
+    it('rebuilds the map when the preview config mtime changes', () => {
+      const { recompile, rebuildCount } = applyPlugin('preview-with-mock.ts')
+
+      recompile(2_000)
+
+      expect(rebuildCount()).toBe(2)
+    })
+
+    // Equality rather than "newer", so restoring an older preview config is still picked up.
+    it('rebuilds the map when the preview config mtime goes backwards', () => {
+      const { recompile, rebuildCount } = applyPlugin('preview-with-mock.ts')
+
+      recompile(500)
+
+      expect(rebuildCount()).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
I had applied a similar fix to #524, but had these additional things too, so with #524 having been merged, I thought the additional changes could still provide some value.

Two bugs stop the mocker runtime reaching the preview, so `sb.mock()` silently does nothing. Neither fires in the default setup: the first needs `html.implementation: 'native'`, the second a second HTML page. Both fail silently when they do. Plus tests for `RspackMockPlugin`, which #524 changed and which has none.

## The runtime is never injected under rspack's HTML plugin

`RspackInjectMockerRuntimePlugin` bails unless the HTML plugin exposes `getHooks`. Rspack's native `HtmlRspackPlugin` only has `getCompilationHooks`:

```console
> typeof rspack.HtmlRspackPlugin.getCompilationHooks
'function'
> typeof rspack.HtmlRspackPlugin.getHooks
'undefined'
```

`getHtmlPlugin` finds that plugin by name, so the check fails and the hook is never tapped. The only trace is an infrastructure logger warning, which Rsbuild suppresses by pinning `infrastructureLogging.level` to `'error'`.

Fixed by preferring `getCompilationHooks` and falling back to `getHooks`. Both are plain statics that ignore `this`, so calling the extracted function unbound is safe.

## Only the first HTML page references it

Once injection runs, the emit guard also gates the tag:

```ts
if (!compilation.getAsset(runtimeAssetName)) {
  compilation.emitAsset(runtimeAssetName, new Sources.RawSource(runtimeScriptContent))
  data.assets.js.unshift(runtimeAssetName)
}
```

`beforeAssetTagGeneration` runs once per HTML page, each with its own asset list, and the asset already exists by the second page. So every page after the first goes without the runtime.

The guard stops an identical asset being re-emitted on every rebuild, which loops the dev server, so it stays around the emit. The tag is now prepended unconditionally.

## Tests

Both plugins are driven against a stub compiler, since rspack's builtins cannot be applied to one.

`RspackInjectMockerRuntimePlugin`, five tests: the HTML plugin exposes one hooks api at a time, and the tag hook runs once per page to record what that page references. Each fix is pinned on its own. Against the old code the `getCompilationHooks` path fails, and with only the tag guard restored the second page comes back empty.

`RspackMockPlugin`, six tests over what #524 added. Worth pinning because losing the empty-map early return costs nothing functionally and just makes every build slow again. That guard uses the absence of a debug message as evidence resolution was never attempted, since the plugin logs only on a failed resolve and the request is unresolvable. The bare-specifier filter is a pure optimisation, so its test pins the outcome rather than the shortcut. The rest cover the mtime cache, including that restoring an older preview config invalidates the map where an "is newer" comparison would not.

`packages/builder-rsbuild` is green: 52 passing, biome clean, `tsc --noEmit` clean.

Not covered: the mock fixture redirects through `__mocks__`, because `import.meta.resolve` of the automock loader's subpath is unavailable inside the test bundle, leaving the automock branch untested.
