### PR TITLE
fix(addon-rslib): support configs without lib

### DIFF
--- a/packages/addon-rslib/__tests__/preset.test.ts
+++ b/packages/addon-rslib/__tests__/preset.test.ts
@@ -1,7 +1,7 @@
 import type { RsbuildConfig } from '@rsbuild/core'
 import { beforeEach, describe, expect, it, rs } from '@rstest/core'
-import { rsbuildFinal } from '../src/preset'
-import type { AddonOptions } from '../src/types'
+import { rsbuildFinal } from '../src/preset.ts'
+import type { AddonOptions } from '../src/types.ts'
 
 type RsbuildFinalOptions = Parameters<NonNullable<typeof rsbuildFinal>>[1]
 

--- a/packages/addon-rslib/rstest.config.ts
+++ b/packages/addon-rslib/rstest.config.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from '@rstest/core'
+import { rstestCommonConfig } from '../../rstest.config'
+
+export default defineConfig({
+  ...rstestCommonConfig,
+  setupFiles: [
+    fileURLToPath(new URL('../../rstest-setup.ts', import.meta.url)),
+  ],
+  testEnvironment: 'node',
+})

--- a/packages/addon-rslib/rstest.config.ts
+++ b/packages/addon-rslib/rstest.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from '@rstest/core'
-import { rstestCommonConfig } from '../../rstest.config'
+import { rstestCommonConfig } from '../../rstest.config.ts'
 
 export default defineConfig({
   ...rstestCommonConfig,

--- a/packages/addon-rslib/src/preset.ts
+++ b/packages/addon-rslib/src/preset.ts
@@ -25,7 +25,13 @@ export const rsbuildFinal: StorybookConfigRsbuild['rsbuildFinal'] = async (
     path: configPath,
   })
 
-  const libConfig = libIndex === false ? {} : content.lib[libIndex]
+  const libConfigs = content.lib === undefined ? [{}] : content.lib
+  const libConfig =
+    libIndex === false
+      ? {}
+      : Array.isArray(libConfigs)
+        ? libConfigs[libIndex]
+        : undefined
   if (!libConfig) {
     throw new Error(
       `Lib config not found at index ${libIndex}, expect a lib config but got ${libConfig}`,

--- a/packages/addon-rslib/tests/preset.test.ts
+++ b/packages/addon-rslib/tests/preset.test.ts
@@ -1,0 +1,95 @@
+import type { RsbuildConfig } from '@rsbuild/core'
+import { beforeEach, describe, expect, it, rs } from '@rstest/core'
+import { rsbuildFinal } from '../src/preset'
+import type { AddonOptions } from '../src/types'
+
+type RsbuildFinalOptions = Parameters<NonNullable<typeof rsbuildFinal>>[1]
+
+const loadConfigMock = rs.hoisted(() => rs.fn())
+
+rs.mock('@rslib/core', () => ({
+  loadConfig: loadConfigMock,
+}))
+
+const runRsbuildFinal = async (
+  content: Record<string, unknown>,
+  rslib?: AddonOptions['rslib'],
+  config: RsbuildConfig = {},
+) => {
+  loadConfigMock.mockResolvedValueOnce({ content })
+  return rsbuildFinal!(config, { rslib } as RsbuildFinalOptions)
+}
+
+describe('rsbuildFinal', () => {
+  beforeEach(() => {
+    loadConfigMock.mockReset()
+  })
+
+  it('uses an implicit lib and merges the top-level config', async () => {
+    const storybookPlugin = { name: 'storybook-plugin', setup: rs.fn() }
+    const rslibPlugin = { name: 'rslib-plugin', setup: rs.fn() }
+
+    const result = await runRsbuildFinal(
+      {
+        output: { target: 'web' },
+        plugins: [rslibPlugin],
+        source: { alias: { '@shared': './src/shared' } },
+      },
+      undefined,
+      { plugins: [storybookPlugin] },
+    )
+
+    expect(result).toMatchObject({
+      output: { target: 'web' },
+      plugins: [storybookPlugin, rslibPlugin],
+      source: { alias: { '@shared': './src/shared' } },
+    })
+  })
+
+  it('throws a friendly error for a missing implicit lib index', async () => {
+    await expect(
+      runRsbuildFinal({ output: { target: 'web' } }, { libIndex: 1 }),
+    ).rejects.toThrow(
+      'Lib config not found at index 1, expect a lib config but got undefined',
+    )
+  })
+
+  it('selects an explicit lib by index', async () => {
+    const result = await runRsbuildFinal(
+      {
+        source: { define: { SHARED: 'true' } },
+        lib: [
+          { source: { define: { FIRST_LIB: 'true' } } },
+          { source: { define: { SECOND_LIB: 'true' } } },
+        ],
+      },
+      { libIndex: 1 },
+    )
+
+    expect(result.source?.define).toEqual({
+      SHARED: 'true',
+      SECOND_LIB: 'true',
+    })
+  })
+
+  it('ignores explicit libs when libIndex is false', async () => {
+    const modifyLibConfig = rs.fn()
+    const result = await runRsbuildFinal(
+      {
+        output: { target: 'web' },
+        source: { define: { TOP_LEVEL: 'true' } },
+        lib: [
+          {
+            output: { target: 'node' },
+            source: { define: { LIB_ONLY: 'true' } },
+          },
+        ],
+      },
+      { libIndex: false, modifyLibConfig },
+    )
+
+    expect(modifyLibConfig).toHaveBeenCalledWith({})
+    expect(result.output?.target).toBe('web')
+    expect(result.source?.define).toEqual({ TOP_LEVEL: 'true' })
+  })
+})


### PR DESCRIPTION
## Summary

Rslib supports omitting `lib` for a single-output library, but `storybook-addon-rslib` indexed the missing array and crashed with its default options. This PR mirrors Rslib's implicit `[{}]` fallback while preserving explicit index selection and `libIndex: false` behavior.

## Validation

- `pnpm exec biome check --write packages/addon-rslib/src/preset.ts packages/addon-rslib/__tests__/preset.test.ts packages/addon-rslib/rstest.config.ts`
- `pnpm exec rstest packages/addon-rslib/__tests__/preset.test.ts`
- `pnpm --filter storybook-addon-rslib check`

## Related Links

- https://github.com/web-infra-dev/rslib/blob/f85250606cf806dd07f9dcdaca666a614039203f/packages/core/src/config.ts#L1835-L1869