### PR TITLE
refactor(builder-rsbuild): follow up on the mocker runtime injection fix

### DIFF
--- a/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-inject-mocker-runtime-plugin.ts
@@ -29,6 +29,10 @@ export class RspackInjectMockerRuntimePlugin {
 
   apply(compiler: Rspack.Compiler) {
     const HtmlPlugin = this.getHtmlPlugin(compiler)
+    // DIVERGES FROM UPSTREAM — upstream only reads `getHooks`, which is enough for
+    // html-webpack-plugin but not here: rspack's native `HtmlRspackPlugin` dropped that
+    // deprecated alias in v2 and offers `getCompilationHooks` alone, so `html.implementation:
+    // 'native'` would leave the hook untapped. Both are plain statics that ignore `this`.
     const getHtmlHooks = HtmlPlugin?.getCompilationHooks ?? HtmlPlugin?.getHooks
     if (typeof getHtmlHooks !== 'function') {
       compiler
@@ -65,6 +69,14 @@ export class RspackInjectMockerRuntimePlugin {
 
             // Reference it from every page though. This hook runs once per HTML page, each
             // with its own asset list, and each page needs the runtime before its scripts.
+            //
+            // DIVERGES FROM UPSTREAM — do not "sync" this back by copying webpack5's
+            // webpack-inject-mocker-runtime-plugin.ts. Upstream still keeps this `unshift`
+            // inside the emit guard above, so only its first HTML page references the runtime
+            // and `sb.mock()` silently does nothing on every later page. The bug is invisible
+            // upstream because its preview emits a single `iframe.html`. See #531, and the
+            // upstream commit that introduced it:
+            // https://github.com/storybookjs/storybook/commit/5c0c2779
             data.assets.js.unshift(runtimeAssetName)
 
             cb(null, data)

--- a/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
+++ b/packages/builder-rsbuild/src/plugins/rspack-mock-plugin.ts
@@ -1,7 +1,6 @@
 import { dirname, isAbsolute } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Rspack } from '@rsbuild/core'
-import { rspack } from '@rsbuild/core'
 import { findMockRedirect } from '@vitest/mocker/redirect'
 import {
   babelParser,
@@ -91,7 +90,10 @@ export class RspackMockPlugin {
     compiler.hooks.beforeRun.tap(PLUGIN_NAME, updateMocks)
     compiler.hooks.watchRun.tap(PLUGIN_NAME, updateMocks)
 
-    new rspack.NormalModuleReplacementPlugin(/.*/, (resource) => {
+    // Taken from the compiler rather than the module-level `rspack` namespace, matching
+    // upstream's webpack5 builder. It keeps the plugin bound to the compiler that is actually
+    // running it, and lets tests supply the constructor instead of patching a shared export.
+    new compiler.webpack.NormalModuleReplacementPlugin(/.*/, (resource) => {
       try {
         // Skip the resolution probe entirely when no `sb.mock()` calls are declared —
         // otherwise every request in the module graph pays for a `require.resolve`-style

--- a/packages/builder-rsbuild/tests/plugins/rspack-inject-mocker-runtime-plugin.test.ts
+++ b/packages/builder-rsbuild/tests/plugins/rspack-inject-mocker-runtime-plugin.test.ts
@@ -4,14 +4,16 @@ import { RspackInjectMockerRuntimePlugin } from '../../src/plugins/rspack-inject
 
 const RUNTIME_ASSET = 'mocker-runtime-injected.js'
 
-type HooksApi = 'getCompilationHooks' | 'getHooks' | 'neither'
+type HooksAccessor = 'getCompilationHooks' | 'getHooks'
+
+type HooksApi = HooksAccessor | 'both' | 'neither'
 
 type TagData = { assets: { js: string[] } }
 
 /**
  * Applies the plugin against a stub compiler whose HTML plugin exposes `api`, and returns handles
- * on what the plugin did with it: whether it tapped the hook at all, what it emitted, and a way to
- * run the hook once per HTML page.
+ * on what the plugin did with it: whether it tapped the hook at all, which accessor it went
+ * through, what it emitted, and a way to run the hook once per HTML page.
  *
  * `getHtmlPlugin` locates the HTML plugin by constructor name, so the stubs have to be named after
  * the real ones.
@@ -20,28 +22,36 @@ function applyPlugin(api: HooksApi) {
   const warnings: string[] = []
   const emitted: string[] = []
   const errors: unknown[] = []
+  const tappedVia: HooksAccessor[] = []
   let tagHook:
     | ((data: TagData, cb: (error: unknown) => void) => void)
     | undefined
   let startCompilation: ((compilation: unknown) => void) | undefined
 
-  const hooks = {
+  // One hooks object per accessor, each recording the route it was reached by, so a plugin that
+  // offers both names can report which one the code under test actually picked.
+  const createHooks = (via: HooksAccessor) => ({
     beforeAssetTagGeneration: {
       tapAsync: (_name: string, fn: typeof tagHook) => {
+        tappedVia.push(via)
         tagHook = fn
       },
     },
-  }
+  })
 
   /**
    * Builds a stand-in HTML plugin instance. The name matters because `getHtmlPlugin` finds the
-   * plugin by constructor name, and the hooks accessor has to sit on the constructor because that
-   * is where the plugin reads it from.
+   * plugin by constructor name, and the hooks accessors have to sit on the constructor because
+   * that is where the plugin reads them from.
    */
-  const createHtmlPlugin = (name: string, accessor?: HooksApi): object => {
+  const createHtmlPlugin = (
+    name: string,
+    accessors: HooksAccessor[],
+  ): object => {
     const Plugin = class {}
     Object.defineProperty(Plugin, 'name', { value: name })
-    if (accessor && accessor !== 'neither') {
+    for (const accessor of accessors) {
+      const hooks = createHooks(accessor)
       Object.defineProperty(Plugin, accessor, { value: () => hooks })
     }
     return new Plugin()
@@ -50,13 +60,19 @@ function applyPlugin(api: HooksApi) {
   let htmlPlugin: object
   switch (api) {
     case 'getCompilationHooks':
-      htmlPlugin = createHtmlPlugin('HtmlRspackPlugin', 'getCompilationHooks')
+      htmlPlugin = createHtmlPlugin('HtmlRspackPlugin', ['getCompilationHooks'])
       break
     case 'getHooks':
-      htmlPlugin = createHtmlPlugin('HtmlWebpackPlugin', 'getHooks')
+      htmlPlugin = createHtmlPlugin('HtmlWebpackPlugin', ['getHooks'])
+      break
+    case 'both':
+      htmlPlugin = createHtmlPlugin('HtmlRspackPlugin', [
+        'getCompilationHooks',
+        'getHooks',
+      ])
       break
     default:
-      htmlPlugin = createHtmlPlugin('HtmlRspackPlugin')
+      htmlPlugin = createHtmlPlugin('HtmlRspackPlugin', [])
   }
 
   const assets = new Map<string, unknown>()
@@ -114,6 +130,7 @@ function applyPlugin(api: HooksApi) {
     warnings,
     errors,
     tapped: () => tagHook !== undefined,
+    usedApi: () => tappedVia[0],
   }
 }
 
@@ -134,6 +151,18 @@ describe('RspackInjectMockerRuntimePlugin', () => {
     it('taps the hook when the plugin only exposes the deprecated getHooks', () => {
       const { renderPage, warnings, errors } = applyPlugin('getHooks')
 
+      expect(renderPage()).toContain(RUNTIME_ASSET)
+      expect(warnings).toEqual([])
+      expect(errors).toEqual([])
+    })
+
+    // The path almost every user is on: html-rspack-plugin, behind the default
+    // `html.implementation: 'js'`, exports both names, and so does rspack v1. Pinning the
+    // preference means the deprecated alias can be dropped without silently changing behaviour.
+    it('prefers getCompilationHooks when the plugin exposes both', () => {
+      const { renderPage, usedApi, warnings, errors } = applyPlugin('both')
+
+      expect(usedApi()).toBe('getCompilationHooks')
       expect(renderPage()).toContain(RUNTIME_ASSET)
       expect(warnings).toEqual([])
       expect(errors).toEqual([])

--- a/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
+++ b/packages/builder-rsbuild/tests/plugins/rspack-mock-plugin.test.ts
@@ -1,12 +1,14 @@
 import { resolve } from 'node:path'
 import type { Rspack } from '@rsbuild/core'
-import { rspack } from '@rsbuild/core'
 import { describe, expect, it } from '@rstest/core'
 import { resolve as resolvePosix } from 'pathe'
 import { RspackMockPlugin } from '../../src/plugins/rspack-mock-plugin'
 
-// extractMockCalls sends telemetry when it finds mocks.
-process.env.STORYBOOK_DISABLE_TELEMETRY = 'true'
+// `extractMockCalls` calls `telemetry('mocking', ...)` whenever it finds mocks, but nothing
+// leaves this process: `telemetry()` gates on `globalThis.SB_TELEMETRY_STATE`, which only the
+// CLI and the common preset ever set. Undefined here means every event is parked on
+// `globalThis.SB_TELEMETRY_QUEUE` and never flushed. Setting `STORYBOOK_DISABLE_TELEMETRY`
+// would not help either — `telemetry()` never reads it.
 
 const fixtureDir = resolve(__dirname, '../fixtures/mock-plugin')
 
@@ -60,27 +62,25 @@ function applyPlugin(
         warn: (message: string) => warnMessages.push(message),
         debug: (message: string) => debugMessages.push(message),
       }) as unknown as InfrastructureLogger,
+    // The plugin reads `NormalModuleReplacementPlugin` off the compiler, so the stub can hand
+    // it a recorder and keep hold of the replacement callback. Nothing global is touched.
+    webpack: {
+      NormalModuleReplacementPlugin: class {
+        constructor(_test: RegExp, callback: (resource: Resource) => void) {
+          replaceResource = callback
+        }
+        apply() {}
+      },
+    } as unknown as Rspack.Compiler['webpack'],
   } satisfies Partial<Rspack.Compiler>
 
   // `Rspack.Compiler` declares a private field, so it is nominally typed and no object literal
   // can be asserted to it directly. The `satisfies` above is what type-checks the stub.
   const compiler = compilerStub as unknown as Rspack.Compiler
 
-  const OriginalPlugin = rspack.NormalModuleReplacementPlugin
-  ;(rspack as any).NormalModuleReplacementPlugin = class {
-    constructor(_test: RegExp, callback: (resource: Resource) => void) {
-      replaceResource = callback
-    }
-    apply() {}
-  }
-
-  try {
-    new RspackMockPlugin({
-      previewConfigPath: resolve(fixtureDir, previewConfig),
-    }).apply(compiler)
-  } finally {
-    ;(rspack as any).NormalModuleReplacementPlugin = OriginalPlugin
-  }
+  new RspackMockPlugin({
+    previewConfigPath: resolve(fixtureDir, previewConfig),
+  }).apply(compiler)
 
   if (!replaceResource || !refreshMocks) {
     throw new Error('plugin did not register its replacement callback')


### PR DESCRIPTION
Follow-up to #531. No behaviour change beyond the plugin construction site.

## Mark the two upstream divergences

Both edits #531 made to `rspack-inject-mocker-runtime-plugin.ts` read as drift against Storybook's webpack5 builder, and a well-meaning sync would undo both. Comments now say so at each site:

- Upstream reads only `getHooks`. Rspack's native `HtmlRspackPlugin` dropped that deprecated alias in v2 and offers `getCompilationHooks` alone.
- Upstream still keeps the tag `unshift` inside the emit guard, so only its first HTML page references the runtime. It cannot see the bug because its preview emits a single `iframe.html`; we inherited the code, not the immunity.

## Read `NormalModuleReplacementPlugin` from the compiler

`RspackMockPlugin` took it off the module-level `rspack` namespace, which forced the test to swap the constructor on that shared export and restore it in a `finally`. Upstream's webpack5 builder reads it from the compiler; do the same, and let the stub compiler supply a recorder instead. The global patch is gone.

Also drops `process.env.STORYBOOK_DISABLE_TELEMETRY` from that test. It never did anything. `extractMockCalls` does call `telemetry('mocking', ...)`, but `telemetry()` gates on `globalThis.SB_TELEMETRY_STATE` and never reads that variable — only the CLI and the common preset do, to call `setTelemetryEnabled()`. Unset, as it is under test, every event is parked on `globalThis.SB_TELEMETRY_QUEUE` and never flushed. Replaced with a comment recording why nothing escapes.

## Pin which hooks accessor the HTML plugin is read through

The suite covered a plugin exposing `getCompilationHooks` alone, `getHooks` alone, and neither — but not both at once. Both is what `html-rspack-plugin` exports behind the default `html.implementation: 'js'`, and what rspack v1 exports too, so it is the path nearly every build takes.

Each accessor now gets its own hooks object so the stub can report the route taken. Flipping the `??` operands in the plugin fails this test and only this test; the other five stay green.

## Checks

- `rstest` in `packages/builder-rsbuild`: 53 passing, up from 52
- `biome check` clean, `tsc --noEmit` clean
- `pnpm e2e react-18.spec.ts`: 3 passing — worth calling out, since the unit tests drive a stub constructor and would not notice if the compiler-supplied `NormalModuleReplacementPlugin` behaved differently

## Two things found along the way, not addressed here

- `html.implementation: 'native'` does not build with this builder at all — `Failed to create Rspack compiler instance`, before the injection hook could run. The `getCompilationHooks` fix is one link in a chain that is currently broken elsewhere, most likely the `tools.htmlPlugin` options the preview relies on (`inject: false`, `.ejs` template, `chunksSortMode`, `alwaysWriteToDisk`).
- `RspackInjectMockerRuntimePlugin` has no end-to-end coverage. The react-18 sandbox mocks through a hand-written `__mocks__` file, which is a build-time redirect and never exercises the runtime. A check that `iframe.html` references `mocker-runtime-injected.js` ahead of the other bundles would close that gap.
