### PR TITLE
docs: correct lazyCompilation default value

### DIFF
--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -72,7 +72,7 @@ const config: StorybookConfig = {
         // Default: false
         fsCache: true,
         
-        // Enable lazy compilation (experimental)
+        // Lazy-compile entries as well as dynamic imports
         // lazyCompilation: true,
 
         // Specify Rsbuild environment to use (for multi-environment configs)
@@ -91,8 +91,10 @@ export default config;
 | :--- | :--- | :--- | :--- |
 | `rsbuildConfigPath` | `string` | `cwd/rsbuild.config.ts` | Path to an existing Rsbuild config file to merge. |
 | `fsCache` | `boolean` | `false` | Enables Rspack's persistent filesystem cache. |
-| `lazyCompilation` | `boolean` | `false` | Enables lazy compilation for faster dev startup. |
+| `lazyCompilation` | `boolean` \| [`LazyCompilationOptions`](https://rspack.rs/config/lazy-compilation) | `{ entries: false }` (development); `false` (production) | Configures Rspack's lazy compilation. |
 | `environment` | `string` | `undefined` | Selects a specific [environment](https://rsbuild.rs/config/environments) from Rsbuild config. |
+
+In development, the default `{ entries: false }` compiles entry chunks eagerly while lazily compiling dynamically imported story modules. Lazy compilation is always disabled in production. In development, automatic MSW detection also changes the default to `false` unless you explicitly configure this option. This differs from the Storybook webpack builder, where lazy compilation is opt-in and remains off unless enabled.
 
 ## Webpack Addons Compatibility
 

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -94,7 +94,7 @@ export default config;
 | `lazyCompilation` | `boolean` \| [`LazyCompilationOptions`](https://rspack.rs/config/lazy-compilation) | `{ entries: false }` (development); `false` (production) | Configures Rspack's lazy compilation. |
 | `environment` | `string` | `undefined` | Selects a specific [environment](https://rsbuild.rs/config/environments) from Rsbuild config. |
 
-In development, the default `{ entries: false }` compiles entry chunks eagerly while lazily compiling dynamically imported story modules. Lazy compilation is always disabled in production. In development, automatic MSW detection also changes the default to `false` unless you explicitly configure this option. This differs from the Storybook webpack builder, where lazy compilation is opt-in and remains off unless enabled.
+In development, the default `{ entries: false }` compiles entry chunks eagerly while lazily compiling dynamically imported story modules. In production, this builder option is not applied, so lazy compilation remains off by default; lower-level Rsbuild or Rspack configuration can override that behavior. In development, automatic MSW detection also changes the default to `false` unless you explicitly configure this option. This differs from the Storybook webpack builder, where lazy compilation is opt-in and remains off unless enabled.
 
 ## Webpack Addons Compatibility
 

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -94,7 +94,7 @@ export default config;
 | `lazyCompilation` | `boolean` \| [`LazyCompilationOptions`](https://rspack.rs/config/lazy-compilation) | `{ entries: false }`（development）；`false`（production） | 配置 Rspack 的 lazy compilation。 |
 | `environment` | `string` | `undefined` | 从 Rsbuild 配置中选择特定的 [environment](https://rsbuild.rs/config/environments)。 |
 
-在 development 中，默认值 `{ entries: false }` 会立即编译 entry chunk，同时对 dynamically imported story module 使用 lazy compilation。production 始终禁用 lazy compilation。在 development 中，自动检测到 MSW 也会将默认值改为 `false`，除非你显式配置此选项。这与 Storybook webpack builder 不同，后者的 lazy compilation 是 opt-in，除非显式启用，否则保持关闭。
+在 development 中，默认值 `{ entries: false }` 会立即编译 entry chunk，同时对 dynamically imported story module 使用 lazy compilation。在 production 中，此 builder option 不会应用，因此 lazy compilation 默认保持关闭；底层 Rsbuild 或 Rspack 配置仍可覆盖该行为。在 development 中，自动检测到 MSW 也会将默认值改为 `false`，除非你显式配置此选项。这与 Storybook webpack builder 不同，后者的 lazy compilation 是 opt-in，除非显式启用，否则保持关闭。
 
 ## Webpack Addons 兼容性
 

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -72,7 +72,7 @@ const config: StorybookConfig = {
         // Default: false
         fsCache: true,
         
-        // Enable lazy compilation (experimental)
+        // Lazy-compile entries as well as dynamic imports
         // lazyCompilation: true,
 
         // Specify Rsbuild environment to use (for multi-environment configs)
@@ -91,8 +91,10 @@ export default config;
 | :--- | :--- | :--- | :--- |
 | `rsbuildConfigPath` | `string` | `cwd/rsbuild.config.ts` | 待合并的已有 Rsbuild 配置文件路径。 |
 | `fsCache` | `boolean` | `false` | 启用 Rspack 的持久化文件系统缓存。 |
-| `lazyCompilation` | `boolean` | `false` | 启用 lazy compilation 以加快开发启动速度。 |
+| `lazyCompilation` | `boolean` \| [`LazyCompilationOptions`](https://rspack.rs/config/lazy-compilation) | `{ entries: false }`（development）；`false`（production） | 配置 Rspack 的 lazy compilation。 |
 | `environment` | `string` | `undefined` | 从 Rsbuild 配置中选择特定的 [environment](https://rsbuild.rs/config/environments)。 |
+
+在 development 中，默认值 `{ entries: false }` 会立即编译 entry chunk，同时对 dynamically imported story module 使用 lazy compilation。production 始终禁用 lazy compilation。在 development 中，自动检测到 MSW 也会将默认值改为 `false`，除非你显式配置此选项。这与 Storybook webpack builder 不同，后者的 lazy compilation 是 opt-in，除非显式启用，否则保持关闭。
 
 ## Webpack Addons 兼容性
 


### PR DESCRIPTION
## Summary

- document the full `lazyCompilation` option type and development/production defaults
- clarify how `{ entries: false }`, MSW auto-detection, and the webpack builder differ
- keep the English and Simplified Chinese configuration guides in sync

## Testing

- `pnpm --dir website build`
- `pnpm lint`
- `pnpm check`
- `pnpm check-dependency-version`
