### PR TITLE
fix: accept resolved paths in framework config types

### DIFF
--- a/packages/framework-html/src/types.ts
+++ b/packages/framework-html/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CompatibleString,
   StorybookConfig as StorybookConfigBase,
   TypescriptOptions as TypescriptOptionsBase,
 } from 'storybook/internal/types'
@@ -8,8 +9,8 @@ import type {
   TypescriptOptions as TypescriptOptionsBuilder,
 } from 'storybook-builder-rsbuild'
 
-type FrameworkName = 'storybook-html-rsbuild'
-type BuilderName = 'storybook-builder-rsbuild'
+type FrameworkName = CompatibleString<'storybook-html-rsbuild'>
+type BuilderName = CompatibleString<'storybook-builder-rsbuild'>
 
 export type FrameworkOptions = {
   builder?: BuilderOptions

--- a/packages/framework-react-native-web/src/types.ts
+++ b/packages/framework-react-native-web/src/types.ts
@@ -1,5 +1,6 @@
 import type { PluginReactNativeWebOptions } from 'rsbuild-plugin-react-native-web'
 import type {
+  CompatibleString,
   StorybookConfig as StorybookConfigBase,
   TypescriptOptions as TypescriptOptionsBase,
 } from 'storybook/internal/types'
@@ -9,8 +10,8 @@ import type {
   TypescriptOptions as TypescriptOptionsBuilder,
 } from 'storybook-builder-rsbuild'
 
-type FrameworkName = 'storybook-react-native-web-rsbuild'
-type BuilderName = 'storybook-builder-rsbuild'
+type FrameworkName = CompatibleString<'storybook-react-native-web-rsbuild'>
+type BuilderName = CompatibleString<'storybook-builder-rsbuild'>
 
 export type FrameworkOptions = {
   builder?: BuilderOptions

--- a/packages/framework-react/src/types.ts
+++ b/packages/framework-react/src/types.ts
@@ -1,5 +1,6 @@
 import type { PluginOptions as ReactDocgenTypescriptOptions } from '@storybook/react-docgen-typescript-plugin'
 import type {
+  CompatibleString,
   StorybookConfig as StorybookConfigBase,
   TypescriptOptions as TypescriptOptionsBase,
 } from 'storybook/internal/types'
@@ -9,8 +10,8 @@ import type {
   TypescriptOptions as TypescriptOptionsBuilder,
 } from 'storybook-builder-rsbuild'
 
-type FrameworkName = 'storybook-react-rsbuild'
-type BuilderName = 'storybook-builder-rsbuild'
+type FrameworkName = CompatibleString<'storybook-react-rsbuild'>
+type BuilderName = CompatibleString<'storybook-builder-rsbuild'>
 
 export type FrameworkOptions = {
   builder?: BuilderOptions

--- a/packages/framework-vue3/src/types.ts
+++ b/packages/framework-vue3/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CompatibleString,
   StorybookConfig as StorybookConfigBase,
   TypescriptOptions as TypescriptOptionsBaseAndVue,
 } from 'storybook/internal/types'
@@ -8,8 +9,8 @@ import type {
   TypescriptOptions as TypescriptOptionsBuilder,
 } from 'storybook-builder-rsbuild'
 
-type FrameworkName = 'storybook-vue3-rsbuild'
-type BuilderName = 'storybook-builder-rsbuild'
+type FrameworkName = CompatibleString<'storybook-vue3-rsbuild'>
+type BuilderName = CompatibleString<'storybook-builder-rsbuild'>
 
 export type FrameworkOptions = {
   builder?: BuilderOptions

--- a/packages/framework-web-components/src/types.ts
+++ b/packages/framework-web-components/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CompatibleString,
   StorybookConfig as StorybookConfigBase,
   TypescriptOptions as TypescriptOptionsWebComponents,
 } from 'storybook/internal/types'
@@ -8,8 +9,8 @@ import type {
   TypescriptOptions as TypescriptOptionsBuilder,
 } from 'storybook-builder-rsbuild'
 
-type FrameworkName = 'storybook-web-components-rsbuild'
-type BuilderName = 'storybook-builder-rsbuild'
+type FrameworkName = CompatibleString<'storybook-web-components-rsbuild'>
+type BuilderName = CompatibleString<'storybook-builder-rsbuild'>
 
 export type FrameworkOptions = {
   builder?: BuilderOptions

--- a/sandboxes/react-18/.storybook/main.ts
+++ b/sandboxes/react-18/.storybook/main.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { StorybookConfig } from 'storybook-react-rsbuild'
 
-const getAbsolutePath = (value: string): any => {
+const getAbsolutePath = (value: string): string => {
   return path.resolve(
     fileURLToPath(
       new URL(import.meta.resolve(`${value}/package.json`, import.meta.url)),


### PR DESCRIPTION
## Summary

- wrap framework and builder package names with `CompatibleString` across all framework packages
- preserve literal autocomplete while accepting absolute paths returned by module-resolution helpers
- type the React 18 sandbox's `getAbsolutePath` helper as `string` to cover the resolved-path configuration

## Testing

- `pnpm lint`
- `pnpm check`
- `pnpm check-dependency-version`
- `pnpm build:sandboxes`
- `pnpm test`
- `pnpm build:test`
- `pnpm e2e`
- `pnpm exec tsc --noEmit -p sandboxes/react-18/tsconfig.json`
