### PR TITLE
ci(release): include Storybook peer bumps in changelog

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,6 +65,17 @@
 			"separateMultipleMajor": false,
 			"enabled": true
 		},
+		// changelogithub omits chore commits, so surface runtime dependency updates
+		// (including enabled peer dependency updates) as bug fixes in release notes.
+		{
+			"matchPackageNames": [
+				"storybook",
+				"@storybook/**",
+				"@rsbuild/**",
+				"@rslib/**"
+			],
+			"semanticCommitType": "fix"
+		},
 		// tsx 4.23.1 appends `?tsx-namespace=<id>` to every specifier resolved by
 		// `tsImport`, including `node:` builtins. Under Rstest's module runner that
 		// specifier is treated as a file path, so `tests/helpers/runCorePreset.ts`

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,12 +68,7 @@
 		// changelogithub omits chore commits, so surface peer dependency range updates
 		// as bug fixes in release notes.
 		{
-			"matchPackageNames": [
-				"storybook",
-				"@storybook/**",
-				"@rsbuild/**",
-				"@rslib/**"
-			],
+			"matchPackageNames": ["storybook"],
 			"matchDepTypes": ["peerDependencies"],
 			"semanticCommitType": "fix"
 		},

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,8 +65,8 @@
 			"separateMultipleMajor": false,
 			"enabled": true
 		},
-		// changelogithub omits chore commits, so surface runtime dependency updates
-		// (including enabled peer dependency updates) as bug fixes in release notes.
+		// changelogithub omits chore commits, so surface peer dependency range updates
+		// as bug fixes in release notes.
 		{
 			"matchPackageNames": [
 				"storybook",
@@ -74,6 +74,7 @@
 				"@rsbuild/**",
 				"@rslib/**"
 			],
+			"matchDepTypes": ["peerDependencies"],
 			"semanticCommitType": "fix"
 		},
 		// tsx 4.23.1 appends `?tsx-namespace=<id>` to every specifier resolved by


### PR DESCRIPTION
## Summary

- mark Renovate Storybook updates as `fix(deps)` only when the grouped update includes a `storybook` peer dependency range bump
- keep ordinary Storybook dependency updates as `chore(deps)` so they remain excluded from release notes

## Why

The release workflow uses `changelogithub`, which includes `fix` commits but omits `chore` commits by default. This makes user-visible peer dependency floor changes appear in the changelog without adding unrelated dependency maintenance.

## Validation

- `pnpm lint`
- `pnpm check`
- `pnpm check-dependency-version`
- `pnpm dlx --package=renovate renovate-config-validator --strict`