### PR TITLE
fix(builder-rsbuild): align pipelined imports with lazy compilation

### DIFF
--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -82,6 +82,42 @@ export type RsbuildBuilderOptions = Options & {
   typescriptOptions: TypescriptOptions
 }
 
+const resolveLazyCompilation = async (
+  options: RsbuildBuilderOptions,
+  builderOptions: BuilderOptions,
+  isProd: boolean,
+  shouldDisableDevFeatures: boolean,
+) => {
+  let lazyCompilationConfig: Rspack.Configuration['lazyCompilation']
+
+  if (!isProd) {
+    if (shouldDisableDevFeatures) {
+      lazyCompilationConfig = false
+    } else if (builderOptions.lazyCompilation !== undefined) {
+      lazyCompilationConfig = builderOptions.lazyCompilation
+    } else if (await isMswActive(options)) {
+      // https://storybook.rsbuild.rs/guide/troubleshooting#msw-integration-and-lazy-compilation
+      lazyCompilationConfig = false
+      logger.warn(dedent`
+        Detected mockServiceWorker.js in staticDirs. Lazy compilation has been disabled
+        automatically to avoid a Service Worker race that can leave the preview iframe
+        blank on cold story loads. Set \`lazyCompilation\` explicitly in your builder
+        options to override.
+      `)
+    } else {
+      lazyCompilationConfig = {
+        entries: false,
+      }
+    }
+  }
+
+  return {
+    lazyCompilationConfig,
+    isLazyCompilationActive:
+      lazyCompilationConfig !== undefined && lazyCompilationConfig !== false,
+  }
+}
+
 export default async (
   options: RsbuildBuilderOptions,
   extraWebpackConfig?: Rspack.Configuration,
@@ -158,28 +194,13 @@ export default async (
   const shouldDisableDevFeatures =
     process.env.SB_RSBUILD_TEST_MINIMAL_DEV === 'true'
 
-  let lazyCompilationConfig: Rspack.Configuration['lazyCompilation']
-
-  if (!isProd) {
-    if (shouldDisableDevFeatures) {
-      lazyCompilationConfig = false
-    } else if (builderOptions.lazyCompilation !== undefined) {
-      lazyCompilationConfig = builderOptions.lazyCompilation
-    } else if (await isMswActive(options)) {
-      // https://storybook.rsbuild.rs/guide/troubleshooting#msw-integration-and-lazy-compilation
-      lazyCompilationConfig = false
-      logger.warn(dedent`
-        Detected mockServiceWorker.js in staticDirs. Lazy compilation has been disabled
-        automatically to avoid a Service Worker race that can leave the preview iframe
-        blank on cold story loads. Set \`lazyCompilation\` explicitly in your builder
-        options to override.
-      `)
-    } else {
-      lazyCompilationConfig = {
-        entries: false,
-      }
-    }
-  }
+  const { lazyCompilationConfig, isLazyCompilationActive } =
+    await resolveLazyCompilation(
+      options,
+      builderOptions,
+      isProd,
+      shouldDisableDevFeatures,
+    )
 
   const shouldDisableHmr = shouldDisableDevFeatures
 
@@ -200,7 +221,7 @@ export default async (
   }
 
   const { virtualModules: virtualModuleMapping, entries: dynamicEntries } =
-    await getVirtualModules(options)
+    await getVirtualModules(options, isLazyCompilationActive)
 
   let contentFromConfig: RsbuildConfig = {}
   const { content } = await loadConfig({

--- a/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
+++ b/packages/builder-rsbuild/src/preview/virtual-module-mapping.ts
@@ -1,7 +1,6 @@
 import { join, resolve } from 'node:path'
 import slash from 'slash'
 import {
-  getBuilderOptions,
   loadPreviewOrConfigFile,
   normalizeStories,
   readTemplate,
@@ -12,7 +11,6 @@ import type {
   PreviewAnnotation,
 } from 'storybook/internal/types'
 import { toImportFn } from '../../compiled/@storybook/core-webpack'
-import type { BuilderOptions } from '../types'
 
 /**
  * Matches `node_modules` only as a complete path segment OR a complete
@@ -82,11 +80,12 @@ export const excludeNodeModulesFromStoryContext = (
     .join('\n')
 }
 
-export const getVirtualModules = async (options: Options) => {
+export const getVirtualModules = async (
+  options: Options,
+  isLazyCompilationActive: boolean,
+) => {
   const virtualModules: Record<string, string> = {}
-  const builderOptions = await getBuilderOptions<BuilderOptions>(options)
   const workingDir = process.cwd()
-  const isProd = options.configType === 'PRODUCTION'
   const nonNormalizedStories = await options.presets.apply('stories', [])
   const entries = []
 
@@ -118,11 +117,11 @@ export const getVirtualModules = async (options: Options) => {
   const storiesFilename = 'storybook-stories.js'
   const storiesPath = resolve(join(workingDir, storiesFilename))
 
-  const needPipelinedImport =
-    builderOptions.lazyCompilation !== false && !isProd
+  // TODO: Add the upstream builder-webpack5 semver gate for webpack issue #15541
+  // once the Rspack version containing the equivalent fix is identified.
   virtualModules[storiesPath] = excludeNodeModulesFromStoryContext(
     toImportFn(stories, {
-      needPipelinedImport,
+      needPipelinedImport: isLazyCompilationActive,
     }),
     stories,
   )

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -22,6 +22,7 @@ type LazyCompilationOption = Rspack.Configuration['lazyCompilation']
 const createOptions = (
   lazyCompilation: LazyCompilationOption | 'unset' = false,
   configType: 'DEVELOPMENT' | 'PRODUCTION' = 'DEVELOPMENT',
+  staticDirs: unknown = [],
 ) => {
   const builderCoreOptions: Record<string, unknown> = {
     rsbuildConfigPath: fixtureRsbuildConfig,
@@ -56,6 +57,7 @@ const createOptions = (
     ['tags', {}],
     ['build', { test: {} }],
     ['previewAnnotations', []],
+    ['staticDirs', staticDirs],
   ])
 
   const apply = rs.fn(
@@ -139,8 +141,13 @@ describe('iframe-rsbuild.config', () => {
 
   const runRspackTool = async (
     lazyCompilation: LazyCompilationOption | 'unset',
+    staticDirs: unknown = [],
   ) => {
-    const { options } = createOptions(lazyCompilation)
+    const { options } = createOptions(
+      lazyCompilation,
+      'DEVELOPMENT',
+      staticDirs,
+    )
     const config = await createIframeRsbuildConfig(
       options as RsbuildBuilderOptions,
     )
@@ -151,20 +158,25 @@ describe('iframe-rsbuild.config', () => {
     const baseConfig = {} as any
     const addRules = rs.fn()
     const appendRules = rs.fn()
+    let virtualModules: Record<string, string> = {}
 
     const result = (rspackTool as any)(baseConfig, {
       addRules,
       appendRules,
       rspack: {
         experiments: {
-          VirtualModulesPlugin: class VirtualModulesPlugin {},
+          VirtualModulesPlugin: class VirtualModulesPlugin {
+            constructor(modules: Record<string, string>) {
+              virtualModules = modules
+            }
+          },
         },
         ProvidePlugin: class ProvidePlugin {},
       },
       mergeConfig: (c: any) => c,
     }) as any
 
-    return { rspackConfig: result, addRules, appendRules }
+    return { rspackConfig: result, addRules, appendRules, virtualModules }
   }
 
   it('uses entries:false when lazyCompilation is unset', async () => {
@@ -185,6 +197,19 @@ describe('iframe-rsbuild.config', () => {
   it('passes through lazyCompilation options object', async () => {
     const { rspackConfig } = await runRspackTool({ entries: true })
     expect(rspackConfig.lazyCompilation).toEqual({ entries: true })
+  })
+
+  it('disables pipelined imports when MSW disables default lazyCompilation', async () => {
+    const mswStaticDir = resolve(fixtureDir, 'msw-active/public')
+    const { rspackConfig, virtualModules } = await runRspackTool('unset', [
+      mswStaticDir,
+    ])
+    const storiesModule =
+      virtualModules[resolve(process.cwd(), 'storybook-stories.js')]
+
+    expect(rspackConfig.lazyCompilation).toBe(false)
+    expect(storiesModule).toContain('const pipeline = (x) => x();')
+    expect(storiesModule).not.toContain('const importPipeline =')
   })
 
   it('appends raw query fallback rule for asset/source imports', async () => {

--- a/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
+++ b/packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts
@@ -33,7 +33,10 @@ const createOptions = (
 }
 
 const getStoriesModule = async (options: Options) => {
-  const { virtualModules } = await getVirtualModules(options)
+  const { virtualModules } = await getVirtualModules(
+    options,
+    options.configType === 'DEVELOPMENT',
+  )
   const storiesPath = resolve(process.cwd(), 'storybook-stories.js')
   return virtualModules[storiesPath]
 }


### PR DESCRIPTION
## Summary

- resolve the effective lazy-compilation config and active state from one shared computation
- derive pipelined story imports from that effective state instead of the raw builder option
- disable pipelined imports when MSW or the minimal-dev flag disables lazy compilation
- retain the current development default and document the pending Rspack version gate

## Test plan

- `pnpm exec biome check --write packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts packages/builder-rsbuild/src/preview/virtual-module-mapping.ts packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts packages/builder-rsbuild/tests/preview/virtual-module-mapping.test.ts`
- `pnpm exec rstest packages/builder-rsbuild` (42 tests)