### PR TITLE
fix(builder-rsbuild): isolate inherited Rsbuild config

### DIFF
--- a/packages/addon-modernjs/package.json
+++ b/packages/addon-modernjs/package.json
@@ -59,7 +59,7 @@
     "@modern-js/plugin": "^3.0.0",
     "@modern-js/plugin-v2": "^2.70.4",
     "@rsbuild/core": "^1.5.0 || ^2.0.0-0",
-    "storybook-builder-rsbuild": "*"
+    "storybook-builder-rsbuild": "workspace:^"
   },
   "peerDependenciesMeta": {
     "@modern-js/plugin": {

--- a/packages/addon-modernjs/src/preset.ts
+++ b/packages/addon-modernjs/src/preset.ts
@@ -8,9 +8,10 @@ import {
 import { mergeRsbuildConfig, type RsbuildConfig } from '@rsbuild/core'
 import findUp from 'find-up'
 import { logger } from 'rslog'
-import type {
-  RsbuildFinal,
-  StorybookConfigRsbuild,
+import {
+  type RsbuildFinal,
+  type StorybookConfigRsbuild,
+  stripInheritedConfig,
 } from 'storybook-builder-rsbuild'
 import type { AddonOptions } from './types'
 
@@ -116,7 +117,13 @@ export const rsbuildFinal: StorybookConfigRsbuild['rsbuildFinal'] = async (
     normalizedConfig: resolveConfig as AppNormalizedConfig,
   }
 
-  // Inject the extra rsbuild plugins
+  // Modern.js may resolve a different version of @rsbuild/core, cast to align types.
+  stripInheritedConfig(
+    rsbuildConfig as RsbuildConfig,
+    'the loaded Modern.js config',
+  )
+
+  // Add the integration's required plugins after inherited config is stripped.
   rsbuildConfig.plugins = [
     ...rsbuildPlugins,
     ...(rsbuildConfig.plugins || []),
@@ -124,27 +131,6 @@ export const rsbuildFinal: StorybookConfigRsbuild['rsbuildFinal'] = async (
     builderPluginAdapterHooks(adapterParams),
   ]
 
-  // Strip output fields that Storybook's preview iframe owns. builder-rsbuild
-  // hardcodes these in iframe-rsbuild.config.ts as defensive defaults, but that
-  // merge runs *before* the rsbuildFinal hook below — so any value Modern.js
-  // produced silently overrides them via mergeRsbuildConfig. Concrete leaks:
-  //   - distPath:      iframe lands in the host's `dist/`, clobbering `modern build`,
-  //                    and nested asset dirs break relative chunk/url() resolution (#522)
-  //   - assetPrefix:   iframe.html script srcs gain the host CDN prefix (#66/#72/#224)
-  //   - cleanDistPath: Modern.js's default `true` overrides Storybook's explicit `false`
-  //   - filename:      host chunk naming overrides `[name].iframe.bundle.js`
-  if (rsbuildConfig.output) {
-    for (const key of [
-      'distPath',
-      'assetPrefix',
-      'cleanDistPath',
-      'filename',
-    ] as const) {
-      delete rsbuildConfig.output[key]
-    }
-  }
-
-  // Modern.js may resolve a different version of @rsbuild/core, cast to align types.
   const finalConfig = mergeRsbuildConfig(config, rsbuildConfig as RsbuildConfig)
   return finalConfig
 }

--- a/packages/addon-rslib/__tests__/preset.test.ts
+++ b/packages/addon-rslib/__tests__/preset.test.ts
@@ -92,4 +92,69 @@ describe('rsbuildFinal', () => {
     expect(result.output?.target).toBe('web')
     expect(result.source?.define).toEqual({ TOP_LEVEL: 'true' })
   })
+
+  it('strips inherited Rslib config before merging it into Storybook', async () => {
+    const result = await runRsbuildFinal({
+      source: { entry: { shared: './src/shared.ts' } },
+      output: {
+        externals: ['shared-external'],
+        assetPrefix: '/shared/',
+      },
+      plugins: [{ name: 'shared-plugin', setup() {} }],
+      lib: [
+        {
+          source: { entry: { index: './src/index.ts' } },
+          output: {
+            distPath: { root: 'dist' },
+            filename: { js: '[name].js' },
+            cleanDistPath: true,
+          },
+          dev: { writeToDisk: true },
+          tools: {
+            htmlPlugin: false,
+            rspack: {
+              output: {
+                library: { name: 'Library', type: 'umd' },
+                globalObject: 'this',
+                umdNamedDefine: true,
+              },
+            },
+          },
+        },
+      ],
+    })
+
+    expect(result.source?.entry).toBeUndefined()
+    expect(result.output?.distPath).toBeUndefined()
+    expect(result.output?.filename).toBeUndefined()
+    expect(result.output?.cleanDistPath).toBeUndefined()
+    expect(result.output?.externals).toBeUndefined()
+    expect(result.output?.assetPrefix).toBeUndefined()
+    expect(result.plugins).toEqual([
+      expect.objectContaining({ name: 'shared-plugin' }),
+    ])
+    expect(result.tools?.htmlPlugin).toBeUndefined()
+    expect(result.tools?.rspack).toEqual({ output: {} })
+    expect(result.dev?.writeToDisk).toBeUndefined()
+  })
+
+  it('preserves explicit Storybook config applied after stripping', async () => {
+    const explicitPlugin = { name: 'explicit-plugin', setup() {} }
+    const result = await runRsbuildFinal(
+      {
+        output: { externals: ['inherited-external'] },
+        plugins: [{ name: 'inherited-plugin', setup() {} }],
+      },
+      {
+        modifyLibRsbuildConfig(config) {
+          config.output ??= {}
+          config.output.externals = ['explicit-external']
+          config.plugins = [explicitPlugin]
+        },
+      },
+    )
+
+    expect(result.output?.externals).toEqual(['explicit-external'])
+    expect(result.plugins).toContain(explicitPlugin)
+  })
 })

--- a/packages/addon-rslib/package.json
+++ b/packages/addon-rslib/package.json
@@ -52,7 +52,7 @@
   "peerDependencies": {
     "@rsbuild/core": "^1.5.0 || ^2.0.0-0",
     "@rslib/core": ">= 0.1.1 || >= 0.2",
-    "storybook-builder-rsbuild": "*"
+    "storybook-builder-rsbuild": "workspace:^"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/addon-rslib/src/preset.ts
+++ b/packages/addon-rslib/src/preset.ts
@@ -1,8 +1,9 @@
 import { mergeRsbuildConfig, type RsbuildConfig } from '@rsbuild/core'
 import { loadConfig } from '@rslib/core'
-import type {
-  RsbuildFinal,
-  StorybookConfigRsbuild,
+import {
+  type RsbuildFinal,
+  type StorybookConfigRsbuild,
+  stripInheritedConfig,
 } from 'storybook-builder-rsbuild'
 import type { AddonOptions } from './types'
 
@@ -48,23 +49,9 @@ export const rsbuildFinal: StorybookConfigRsbuild['rsbuildFinal'] = async (
     libConfig as RsbuildConfig,
   )
 
-  // TODO: Add more unapplicable fields.
+  stripInheritedConfig(mergedLibConfig, 'the loaded Rslib config')
 
-  // #region Remove unapplicable fields.
-  delete mergedLibConfig.source?.entry
-  delete mergedLibConfig.output?.distPath
-  delete mergedLibConfig.output?.filename
-  delete mergedLibConfig.output?.cleanDistPath
-  delete mergedLibConfig.output?.externals
-  delete mergedLibConfig.server?.publicDir
-  delete mergedLibConfig.dev?.progressBar
-  // #endregion
-
-  // #region Critical in the MF library, but it is appropriate to remove it for all library formats.
-  delete mergedLibConfig.output?.assetPrefix
-  delete mergedLibConfig.dev?.assetPrefix
-  // #endregion
-
+  // Explicit Storybook configuration is applied after inherited fields are stripped.
   if (typeof modifyLibRsbuildConfig === 'function') {
     modifyLibRsbuildConfig(mergedLibConfig)
   }

--- a/packages/addon-rslib/src/types.ts
+++ b/packages/addon-rslib/src/types.ts
@@ -28,8 +28,9 @@ export interface AddonOptions {
      */
     modifyLibConfig?: (config: LibConfig) => void
     /**
-     * Modify the Rsbuild config transformed from lib config before merging with Storybook
-     * config. You can modify the configuration in the config parameters in place.
+     * Modify the Rsbuild config transformed from lib config after inherited fields are stripped
+     * and before merging with Storybook config. You can modify the configuration in the config
+     * parameters in place, including explicitly restoring stripped fields.
      * @experimental subject to change at any time
      * @default undefined
      */

--- a/packages/builder-rsbuild/src/index.ts
+++ b/packages/builder-rsbuild/src/index.ts
@@ -20,6 +20,7 @@ import rsbuildConfig, {
 import { applyReactShims } from './react-shims'
 import type { RsbuildBuilder } from './types'
 
+export { stripInheritedConfig } from './inherited-config'
 export * from './preview/virtual-module-mapping'
 export * from './types'
 
@@ -106,6 +107,8 @@ const rsbuild = async (_: unknown, options: RsbuildBuilderOptions) => {
     shimsConfig,
   ) as rsbuildReal.RsbuildConfig
 
+  // Preset hooks run in order with the user's main.ts last. Inherited configs have already
+  // been stripped, so an explicit rsbuildFinal hook is the escape hatch for restoring fields.
   const finalConfig = await presets.apply(
     'rsbuildFinal',
     intrinsicRsbuildConfig,

--- a/packages/builder-rsbuild/src/inherited-config.ts
+++ b/packages/builder-rsbuild/src/inherited-config.ts
@@ -53,6 +53,12 @@ const stripConfigField = (
   return stripConfigField(target[field], segments, segmentIndex + 1)
 }
 
+/**
+ * Strips fields that are unsafe to inherit into the Storybook preview build.
+ *
+ * @internal For use by official Storybook Rsbuild packages only. This API is subject to change at
+ * any time and should not be used in user configuration.
+ */
 export const stripInheritedConfig = (
   config: RsbuildConfig,
   source: string,

--- a/packages/builder-rsbuild/src/inherited-config.ts
+++ b/packages/builder-rsbuild/src/inherited-config.ts
@@ -1,0 +1,71 @@
+import type { RsbuildConfig } from '@rsbuild/core'
+import { logger } from 'storybook/internal/node-logger'
+
+const inheritedConfigFieldPaths = [
+  'source.entry',
+  'output.distPath',
+  'output.filename',
+  'output.cleanDistPath',
+  'output.externals',
+  'output.assetPrefix',
+  'server.publicDir',
+  'dev.progressBar',
+  'dev.assetPrefix',
+  'dev.writeToDisk',
+  'tools.htmlPlugin',
+  'tools.rspack.output.library',
+  'tools.rspack.output.globalObject',
+  'tools.rspack.output.umdNamedDefine',
+] as const
+
+const stripConfigField = (
+  value: unknown,
+  segments: string[],
+  segmentIndex = 0,
+): boolean => {
+  if (Array.isArray(value)) {
+    let stripped = false
+    for (const item of value) {
+      stripped = stripConfigField(item, segments, segmentIndex) || stripped
+    }
+    return stripped
+  }
+
+  // Function values are opaque, so function-form tools.rspack entries cannot be stripped.
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const target = value as Record<string, unknown>
+  const field = segments[segmentIndex]
+  if (!field) {
+    return false
+  }
+
+  if (segmentIndex === segments.length - 1) {
+    if (target[field] === undefined) {
+      return false
+    }
+    delete target[field]
+    return true
+  }
+
+  return stripConfigField(target[field], segments, segmentIndex + 1)
+}
+
+export const stripInheritedConfig = (
+  config: RsbuildConfig,
+  source: string,
+): string[] => {
+  const strippedFields = inheritedConfigFieldPaths.filter((path) =>
+    stripConfigField(config, path.split('.')),
+  )
+
+  if (strippedFields.length > 0) {
+    logger.warn(
+      `Stripped incompatible fields from ${source} (${strippedFields.join(', ')}) because they can break the Storybook preview build.`,
+    )
+  }
+
+  return strippedFields
+}

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -17,6 +17,7 @@ import { logger } from 'storybook/internal/node-logger'
 import { globalsNameReferenceMap } from 'storybook/internal/preview/globals'
 import type { Options } from 'storybook/internal/types'
 import { dedent } from 'ts-dedent'
+import { stripInheritedConfig } from '../inherited-config'
 import type { BuilderOptions, TypescriptOptions } from '../types'
 import { isMswActive } from './detect-msw'
 import { getVirtualModules } from './virtual-module-mapping'
@@ -264,6 +265,8 @@ export default async (
   } else {
     contentFromConfig = content
   }
+
+  stripInheritedConfig(contentFromConfig, 'the loaded Rsbuild config')
 
   const resourceFilename = isProd
     ? 'static/media/[name].[contenthash:8][ext]'

--- a/packages/builder-rsbuild/tests/fixtures/inheritance-boundary-rsbuild.config.ts
+++ b/packages/builder-rsbuild/tests/fixtures/inheritance-boundary-rsbuild.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from '@rsbuild/core'
+
+export default defineConfig({
+  dev: {
+    writeToDisk: true,
+  },
+  plugins: [
+    {
+      name: 'write-build-id',
+      setup() {},
+    },
+    {
+      name: 'keep-for-storybook',
+      setup() {},
+    },
+  ],
+  tools: {
+    htmlPlugin: false,
+    rspack: {
+      output: {
+        globalObject: 'this',
+        library: {
+          name: 'FixtureLibrary',
+          type: 'umd',
+        },
+        umdNamedDefine: true,
+        uniqueName: 'inheritance-boundary-fixture',
+      },
+    },
+  },
+})

--- a/packages/builder-rsbuild/tests/inherited-config.test.ts
+++ b/packages/builder-rsbuild/tests/inherited-config.test.ts
@@ -1,0 +1,89 @@
+import type { RsbuildConfig } from '@rsbuild/core'
+import { describe, expect, it, rs } from '@rstest/core'
+import { logger } from 'storybook/internal/node-logger'
+import { stripInheritedConfig } from '../src/inherited-config'
+
+const inheritedConfig = (): RsbuildConfig =>
+  ({
+    source: {
+      entry: { index: './src/index.ts' },
+    },
+    output: {
+      distPath: { root: 'dist' },
+      filename: { js: '[name].js' },
+      cleanDistPath: true,
+      externals: ['react'],
+      assetPrefix: '/assets/',
+    },
+    server: {
+      publicDir: { name: 'public' },
+    },
+    dev: {
+      progressBar: true,
+      assetPrefix: '/dev-assets/',
+      writeToDisk: true,
+    },
+    plugins: [{ name: 'inherited-plugin', setup() {} }],
+    tools: {
+      htmlPlugin: false,
+      rspack: [
+        {
+          output: {
+            library: { name: 'Library', type: 'umd' },
+            globalObject: 'this',
+            umdNamedDefine: true,
+            uniqueName: 'keep-me',
+          },
+        },
+        (config: unknown) => config,
+      ],
+    },
+  }) as unknown as RsbuildConfig
+
+describe('stripInheritedConfig', () => {
+  it('strips every field in the inherited config boundary', () => {
+    const config = inheritedConfig()
+    const warn = rs.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    const strippedFields = stripInheritedConfig(config, 'a test config')
+
+    expect(strippedFields).toEqual([
+      'source.entry',
+      'output.distPath',
+      'output.filename',
+      'output.cleanDistPath',
+      'output.externals',
+      'output.assetPrefix',
+      'server.publicDir',
+      'dev.progressBar',
+      'dev.assetPrefix',
+      'dev.writeToDisk',
+      'tools.htmlPlugin',
+      'tools.rspack.output.library',
+      'tools.rspack.output.globalObject',
+      'tools.rspack.output.umdNamedDefine',
+    ])
+    expect(config.source?.entry).toBeUndefined()
+    expect(config.output?.distPath).toBeUndefined()
+    expect(config.output?.filename).toBeUndefined()
+    expect(config.output?.cleanDistPath).toBeUndefined()
+    expect(config.output?.externals).toBeUndefined()
+    expect(config.output?.assetPrefix).toBeUndefined()
+    expect(config.server?.publicDir).toBeUndefined()
+    expect(config.dev?.progressBar).toBeUndefined()
+    expect(config.dev?.assetPrefix).toBeUndefined()
+    expect(config.dev?.writeToDisk).toBeUndefined()
+    expect(config.plugins).toEqual([
+      expect.objectContaining({ name: 'inherited-plugin' }),
+    ])
+    expect(config.tools?.htmlPlugin).toBeUndefined()
+    expect(config.tools?.rspack).toEqual([
+      { output: { uniqueName: 'keep-me' } },
+      expect.any(Function),
+    ])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(
+      `Stripped incompatible fields from a test config (${strippedFields.join(', ')}) because they can break the Storybook preview build.`,
+    )
+  })
+})

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -1,12 +1,21 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import type { Rspack } from '@rsbuild/core'
+import {
+  mergeRsbuildConfig,
+  type RsbuildConfig,
+  type Rspack,
+} from '@rsbuild/core'
 import { describe, expect, it, rs } from '@rstest/core'
+import { getConfig } from '../../src/index'
 import type { RsbuildBuilderOptions } from '../../src/preview/iframe-rsbuild.config'
 import createIframeRsbuildConfig from '../../src/preview/iframe-rsbuild.config'
 
 const fixtureDir = resolve(__dirname, '../fixtures')
 const fixtureRsbuildConfig = resolve(fixtureDir, 'rsbuild.config.ts')
+const inheritanceBoundaryRsbuildConfig = resolve(
+  fixtureDir,
+  'inheritance-boundary-rsbuild.config.ts',
+)
 
 const storybookEntries = ['storybook-entry.js']
 const storiesConfig = [
@@ -23,12 +32,15 @@ const createOptions = (
   lazyCompilation: LazyCompilationOption | 'unset' = false,
   configType: 'DEVELOPMENT' | 'PRODUCTION' = 'DEVELOPMENT',
   staticDirs: unknown = [],
+  builderOptionOverrides: Record<string, unknown> = {},
+  rsbuildFinal?: (config: RsbuildConfig) => RsbuildConfig,
 ) => {
   const builderCoreOptions: Record<string, unknown> = {
     rsbuildConfigPath: fixtureRsbuildConfig,
     addonDocs: {},
     fsCache: false,
     ...(lazyCompilation === 'unset' ? {} : { lazyCompilation }),
+    ...builderOptionOverrides,
   }
 
   const presetValues = new Map<string, unknown>([
@@ -42,7 +54,7 @@ const createOptions = (
       },
     ],
     ['framework', {}],
-    ['frameworkOptions', { renderer: '@storybook/react' }],
+    ['frameworkOptions', { renderer: '@storybook/react', legacyRootApi: true }],
     ['env', { STORYBOOK_ENV: 'development' }],
     ['logLevel', 'info'],
     ['previewHead', '<!-- head -->'],
@@ -58,10 +70,15 @@ const createOptions = (
     ['build', { test: {} }],
     ['previewAnnotations', []],
     ['staticDirs', staticDirs],
+    ['typescript', { check: false, skipCompiler: true }],
   ])
 
   const apply = rs.fn(
     async (name: string, defaultValue?: unknown): Promise<unknown> => {
+      if (name === 'rsbuildFinal' && rsbuildFinal) {
+        return rsbuildFinal(defaultValue as RsbuildConfig)
+      }
+
       if (name === 'mdxLoaderOptions') {
         return defaultValue
       }
@@ -137,6 +154,66 @@ describe('iframe-rsbuild.config', () => {
     )
 
     expect(config.source?.entry).toBeDefined()
+  })
+
+  it('strips library output fields that are incompatible with the preview build', async () => {
+    const { options } = createOptions(false, 'DEVELOPMENT', [], {
+      rsbuildConfigPath: inheritanceBoundaryRsbuildConfig,
+    })
+
+    const config = await createIframeRsbuildConfig(
+      options as RsbuildBuilderOptions,
+    )
+    const rspackConfigs = Array.isArray(config.tools?.rspack)
+      ? config.tools.rspack
+      : [config.tools?.rspack]
+    const inheritedRspackConfig = rspackConfigs.find(
+      (item) => typeof item === 'object' && item.output?.uniqueName,
+    )
+
+    expect(inheritedRspackConfig).toBeDefined()
+    expect(inheritedRspackConfig).not.toHaveProperty('output.library')
+    expect(inheritedRspackConfig).not.toHaveProperty('output.globalObject')
+    expect(inheritedRspackConfig).not.toHaveProperty('output.umdNamedDefine')
+    expect(config.tools?.htmlPlugin).not.toBe(false)
+    expect(config.dev?.writeToDisk).toBeUndefined()
+  })
+
+  it('inherits plugins from the loaded Rsbuild config', async () => {
+    const { options } = createOptions(false, 'DEVELOPMENT', [], {
+      rsbuildConfigPath: inheritanceBoundaryRsbuildConfig,
+    })
+
+    const config = await createIframeRsbuildConfig(
+      options as RsbuildBuilderOptions,
+    )
+
+    expect(config.plugins).toContainEqual(
+      expect.objectContaining({ name: 'write-build-id' }),
+    )
+    expect(config.plugins).toContainEqual(
+      expect.objectContaining({ name: 'keep-for-storybook' }),
+    )
+  })
+
+  it('preserves config explicitly restored by rsbuildFinal', async () => {
+    const explicitPlugin = { name: 'explicit-plugin', setup() {} }
+    const { options } = createOptions(
+      false,
+      'DEVELOPMENT',
+      [],
+      { rsbuildConfigPath: inheritanceBoundaryRsbuildConfig },
+      (config) =>
+        mergeRsbuildConfig(config, {
+          output: { externals: ['explicit-external'] },
+          plugins: [explicitPlugin],
+        }),
+    )
+
+    const config = await getConfig(options as RsbuildBuilderOptions)
+
+    expect(config.output?.externals).toContain('explicit-external')
+    expect(config.plugins).toContain(explicitPlugin)
   })
 
   const runRspackTool = async (

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -98,22 +98,7 @@ The config selected by `rsbuildConfigPath` is automatically merged into the Stor
 
 This boundary also applies to configuration inherited by `storybook-addon-rslib` and `storybook-addon-modernjs`. Function-form `tools.rspack` values are opaque and cannot be stripped. Prefer a dedicated [Rsbuild environment](https://rsbuild.rs/config/environments) selected with `environment` to isolate Storybook-safe settings. To restore a stripped field intentionally, add it explicitly in Storybook's `rsbuildFinal`; explicit configuration runs after inherited configuration is stripped.
 
-Plugins remain inherited because they commonly provide transforms required by the preview build. The Storybook CLI sets `process.env.STORYBOOK` to `'true'` before loading project configuration, so conditionally omit an app-only plugin that should not run in Storybook:
-
-```ts title="rsbuild.config.ts"
-import { defineConfig } from '@rsbuild/core';
-
-const writeBuildIdPlugin = () => ({
-  name: 'write-build-id',
-  setup() {},
-});
-
-export default defineConfig({
-  plugins: [
-    ...(process.env.STORYBOOK === 'true' ? [] : [writeBuildIdPlugin()]),
-  ],
-});
-```
+Plugins remain inherited because they commonly provide transforms required by the preview build. The Storybook CLI sets `process.env.STORYBOOK` to `'true'` before loading project configuration, so use that condition to omit an app-only plugin that should not run in Storybook.
 
 ### Option Reference
 

--- a/website/docs/en/guide/configuration.mdx
+++ b/website/docs/en/guide/configuration.mdx
@@ -85,6 +85,36 @@ const config: StorybookConfig = {
 export default config;
 ```
 
+### Inherited Rsbuild Configuration
+
+The config selected by `rsbuildConfigPath` is automatically merged into the Storybook preview build. Production-only settings can affect or break the preview, so the following fields are not inherited:
+
+- `source.entry`
+- `output.distPath`, `output.filename`, `output.cleanDistPath`, `output.externals`, and `output.assetPrefix`
+- `server.publicDir`
+- `dev.progressBar`, `dev.assetPrefix`, and `dev.writeToDisk`
+- `tools.htmlPlugin`
+- `tools.rspack.output.library`, `tools.rspack.output.globalObject`, and `tools.rspack.output.umdNamedDefine`
+
+This boundary also applies to configuration inherited by `storybook-addon-rslib` and `storybook-addon-modernjs`. Function-form `tools.rspack` values are opaque and cannot be stripped. Prefer a dedicated [Rsbuild environment](https://rsbuild.rs/config/environments) selected with `environment` to isolate Storybook-safe settings. To restore a stripped field intentionally, add it explicitly in Storybook's `rsbuildFinal`; explicit configuration runs after inherited configuration is stripped.
+
+Plugins remain inherited because they commonly provide transforms required by the preview build. The Storybook CLI sets `process.env.STORYBOOK` to `'true'` before loading project configuration, so conditionally omit an app-only plugin that should not run in Storybook:
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+
+const writeBuildIdPlugin = () => ({
+  name: 'write-build-id',
+  setup() {},
+});
+
+export default defineConfig({
+  plugins: [
+    ...(process.env.STORYBOOK === 'true' ? [] : [writeBuildIdPlugin()]),
+  ],
+});
+```
+
 ### Option Reference
 
 | Option | Type | Default | Description |

--- a/website/docs/en/guide/integrations/modernjs.mdx
+++ b/website/docs/en/guide/integrations/modernjs.mdx
@@ -30,6 +30,8 @@ const config: StorybookConfig = {
 export default config
 ```
 
+Before the resolved Modern.js config is merged into Storybook, it passes through the inherited-config boundary documented in [Builder Options](/guide/configuration#builder-options). To restore a stripped field intentionally, add it in Storybook's `rsbuildFinal`; explicit configuration runs after inherited fields are stripped.
+
 ## With Module Federation
 
 Review the [Module Federation example](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes/modernjs-react-mf) for a full walkthrough.
@@ -93,7 +95,7 @@ export default defineConfig({
     appTools({
       bundler: 'rspack',
     }),
-    ...(process.env.STORYBOOK ? [] : [moduleFederationPlugin()]),
+    ...(process.env.STORYBOOK === 'true' ? [] : [moduleFederationPlugin()]),
   ],
 })
 ```

--- a/website/docs/en/guide/integrations/rslib.mdx
+++ b/website/docs/en/guide/integrations/rslib.mdx
@@ -2,7 +2,7 @@ import { PackageManagerTabs } from '@theme'
 
 # Rslib
 
-This addon loads a reusable Rsbuild config from your Rslib configuration file so `storybook-builder-rsbuild` mirrors the same setup used by your library build.
+This addon loads the reusable parts of the Rsbuild config from your Rslib configuration file while keeping library-only settings out of the Storybook preview build.
 
 It also lets you develop the `mf` [(Module Federation)](https://rslib.rs/guide/basic/output-format#mf) format inside Storybook.
 
@@ -24,6 +24,8 @@ export default {
   addons: ['storybook-addon-rslib'],
 }
 ```
+
+Before the selected Rslib config is merged into Storybook, it passes through the same inherited-config boundary documented in [Builder Options](/guide/configuration#builder-options). Plugins remain inherited; use the Storybook CLI's `process.env.STORYBOOK` flag to conditionally omit an app-only side-effect plugin. Use `modifyLibRsbuildConfig` to restore a stripped field explicitly for Storybook, or use Storybook's `rsbuildFinal` for final configuration. Both hooks run after inherited fields are stripped.
 
 Or configure the addon manually:
 
@@ -75,8 +77,9 @@ export interface AddonOptions {
      */
     modifyLibConfig?: (config: LibConfig) => void
     /**
-     * Modify the Rsbuild config transformed from lib config before merging with Storybook
-     * config. You can modify the configuration in the config parameters in place.
+     * Modify the Rsbuild config transformed from lib config after inherited fields are stripped
+     * and before merging with Storybook config. You can modify the configuration in the config
+     * parameters in place, including explicitly restoring stripped fields.
      * @experimental subject to change at any time
      * @default undefined
      */

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -98,22 +98,7 @@ export default config;
 
 此边界也适用于从 `storybook-addon-rslib` 和 `storybook-addon-modernjs` 继承的配置。`tools.rspack` 如果使用函数形式，内部字段将无法被检查和剥离。建议通过 `environment` 选择专用于 Storybook 的 [Rsbuild environment](https://rsbuild.rs/config/environments)。如果确实需要恢复某个已剥离的字段，请在 Storybook 的 `rsbuildFinal` 中显式添加；显式配置会在继承配置被剥离后执行。
 
-Plugin 会继续继承，因为它们通常提供 preview build 所需的 transform。Storybook CLI 会在加载项目配置前将 `process.env.STORYBOOK` 设置为 `'true'`，因此可以按以下方式有条件地排除不应在 Storybook 中运行、仅供应用使用的 plugin：
-
-```ts title="rsbuild.config.ts"
-import { defineConfig } from '@rsbuild/core';
-
-const writeBuildIdPlugin = () => ({
-  name: 'write-build-id',
-  setup() {},
-});
-
-export default defineConfig({
-  plugins: [
-    ...(process.env.STORYBOOK === 'true' ? [] : [writeBuildIdPlugin()]),
-  ],
-});
-```
+Plugin 会继续继承，因为它们通常提供 preview build 所需的 transform。Storybook CLI 会在加载项目配置前将 `process.env.STORYBOOK` 设置为 `'true'`，可以用这个条件排除不应在 Storybook 中运行、仅供应用使用的 plugin。
 
 ### 选项参考
 

--- a/website/docs/zh/guide/configuration.mdx
+++ b/website/docs/zh/guide/configuration.mdx
@@ -85,6 +85,36 @@ const config: StorybookConfig = {
 export default config;
 ```
 
+### 继承的 Rsbuild 配置
+
+`rsbuildConfigPath` 选中的配置会自动合并到 Storybook preview 构建中。仅用于生产环境的设置可能影响或破坏 preview，因此不会继承以下字段：
+
+- `source.entry`
+- `output.distPath`、`output.filename`、`output.cleanDistPath`、`output.externals` 和 `output.assetPrefix`
+- `server.publicDir`
+- `dev.progressBar`、`dev.assetPrefix` 和 `dev.writeToDisk`
+- `tools.htmlPlugin`
+- `tools.rspack.output.library`、`tools.rspack.output.globalObject` 和 `tools.rspack.output.umdNamedDefine`
+
+此边界也适用于从 `storybook-addon-rslib` 和 `storybook-addon-modernjs` 继承的配置。`tools.rspack` 如果使用函数形式，内部字段将无法被检查和剥离。建议通过 `environment` 选择专用于 Storybook 的 [Rsbuild environment](https://rsbuild.rs/config/environments)。如果确实需要恢复某个已剥离的字段，请在 Storybook 的 `rsbuildFinal` 中显式添加；显式配置会在继承配置被剥离后执行。
+
+Plugin 会继续继承，因为它们通常提供 preview build 所需的 transform。Storybook CLI 会在加载项目配置前将 `process.env.STORYBOOK` 设置为 `'true'`，因此可以按以下方式有条件地排除不应在 Storybook 中运行、仅供应用使用的 plugin：
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+
+const writeBuildIdPlugin = () => ({
+  name: 'write-build-id',
+  setup() {},
+});
+
+export default defineConfig({
+  plugins: [
+    ...(process.env.STORYBOOK === 'true' ? [] : [writeBuildIdPlugin()]),
+  ],
+});
+```
+
 ### 选项参考
 
 | Option | Type | Default | Description |

--- a/website/docs/zh/guide/integrations/modernjs.mdx
+++ b/website/docs/zh/guide/integrations/modernjs.mdx
@@ -30,6 +30,8 @@ const config: StorybookConfig = {
 export default config
 ```
 
+解析后的 Modern.js config 在合并到 Storybook 之前，会经过 [Builder 选项](/guide/configuration#builder-选项) 中记录的 inherited-config 边界。如果确实需要恢复某个已剥离的字段，请在 Storybook 的 `rsbuildFinal` 中显式添加；显式配置会在继承字段被剥离后执行。
+
 ## 结合 Module Federation
 
 完整流程请参阅 [Module Federation 示例](https://github.com/rstackjs/storybook-rsbuild/tree/main/sandboxes/modernjs-react-mf)。
@@ -93,7 +95,7 @@ export default defineConfig({
     appTools({
       bundler: 'rspack',
     }),
-    ...(process.env.STORYBOOK ? [] : [moduleFederationPlugin()]),
+    ...(process.env.STORYBOOK === 'true' ? [] : [moduleFederationPlugin()]),
   ],
 })
 ```

--- a/website/docs/zh/guide/integrations/rslib.mdx
+++ b/website/docs/zh/guide/integrations/rslib.mdx
@@ -2,7 +2,7 @@ import { PackageManagerTabs } from '@theme'
 
 # Rslib
 
-该 addon 会从你的 Rslib 配置文件中加载一份可复用的 Rsbuild config，使 `storybook-builder-rsbuild` 与你的库构建所使用的配置保持一致。
+该 addon 会从你的 Rslib 配置文件中加载 Rsbuild config 的可复用部分，同时避免仅用于 library build 的设置进入 Storybook preview build。
 
 它还允许你在 Storybook 内开发 `mf` [(Module Federation)](https://rslib.rs/guide/basic/output-format#mf) 格式。
 
@@ -24,6 +24,8 @@ export default {
   addons: ['storybook-addon-rslib'],
 }
 ```
+
+选中的 Rslib 配置在合并到 Storybook 之前，会经过 [Builder 选项](/guide/configuration#builder-选项) 中记录的同一 inherited-config 边界。Plugin 会继续继承；可以使用 Storybook CLI 的 `process.env.STORYBOOK` 标志，有条件地排除仅供应用使用的 side-effect plugin。可以使用 `modifyLibRsbuildConfig` 为 Storybook 显式恢复已剥离的字段，也可以使用 Storybook 的 `rsbuildFinal` 进行最终配置。这两个 hook 都在继承字段被剥离后执行。
 
 或者手动配置该 addon：
 
@@ -75,8 +77,9 @@ export interface AddonOptions {
      */
     modifyLibConfig?: (config: LibConfig) => void
     /**
-     * Modify the Rsbuild config transformed from lib config before merging with Storybook
-     * config. You can modify the configuration in the config parameters in place.
+     * Modify the Rsbuild config transformed from lib config after inherited fields are stripped
+     * and before merging with Storybook config. You can modify the configuration in the config
+     * parameters in place, including explicitly restoring stripped fields.
      * @experimental subject to change at any time
      * @default undefined
      */


### PR DESCRIPTION
## Summary

- centralize the fields that must not be inherited from application and library build configurations
- apply the same inheritance boundary to the Rsbuild builder, Rslib addon, and Modern.js addon while preserving user plugins
- keep explicit Storybook hooks as an escape hatch and document `process.env.STORYBOOK` for app-only plugins
- require a compatible builder version from addons that consume the shared boundary helper

## Testing

- `pnpm lint`
- `pnpm check`
- `pnpm check-dependency-version`
- `pnpm build`
- `pnpm build:sandboxes`
- `pnpm test`
- `pnpm build:test`
- `pnpm e2e` (22 passed, 1 skipped)
- `pnpm --dir website build`
