### PR TITLE
fix(builder-rsbuild): inherit a single named environment

### DIFF
--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -240,7 +240,7 @@ export default async (
       // Directly use the unique environment.
       contentFromConfig = mergeRsbuildConfig(
         withoutEnv,
-        content.environments[0],
+        Object.values(content.environments)[0],
       )
     } else {
       // User need to specify the environment first if more than one provided.

--- a/packages/builder-rsbuild/tests/fixtures/single-environment-rsbuild.config.ts
+++ b/packages/builder-rsbuild/tests/fixtures/single-environment-rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core'
+
+export default defineConfig({
+  environments: {
+    web: {
+      resolve: {
+        alias: {
+          'single-environment-alias': './single-environment-target.ts',
+        },
+      },
+    },
+  },
+})

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -16,6 +16,10 @@ const inheritanceBoundaryRsbuildConfig = resolve(
   fixtureDir,
   'inheritance-boundary-rsbuild.config.ts',
 )
+const singleEnvironmentRsbuildConfig = resolve(
+  fixtureDir,
+  'single-environment-rsbuild.config.ts',
+)
 
 const storybookEntries = ['storybook-entry.js']
 const storiesConfig = [
@@ -194,6 +198,20 @@ describe('iframe-rsbuild.config', () => {
     expect(config.plugins).toContainEqual(
       expect.objectContaining({ name: 'keep-for-storybook' }),
     )
+  })
+
+  it('inherits config from a single named Rsbuild environment', async () => {
+    const { options } = createOptions(false, 'DEVELOPMENT', [], {
+      rsbuildConfigPath: singleEnvironmentRsbuildConfig,
+    })
+
+    const config = await createIframeRsbuildConfig(
+      options as RsbuildBuilderOptions,
+    )
+
+    expect(config.resolve?.alias).toMatchObject({
+      'single-environment-alias': './single-environment-target.ts',
+    })
   })
 
   it('preserves config explicitly restored by rsbuildFinal', async () => {


### PR DESCRIPTION
## Summary

- load a single named Rsbuild environment from the keyed environment map
- add a regression fixture proving environment-scoped configuration is inherited

## Problem

Rsbuild stores `environments` as a keyed object. The single-environment branch read index `0`, so a normal config such as `{ environments: { web: { ... } } }` produced `undefined` and silently dropped the environment-scoped settings.

## Validation

- `pnpm lint`
- `pnpm check-dependency-version`
- `pnpm check`
- `pnpm build:test`
- `pnpm build:sandboxes`
- `pnpm --dir website build`
- `pnpm test` on Node 22 (108 passed, 11 skipped)
- `pnpm e2e` on Node 22 (15 passed, 8 skipped)