### PR TITLE
fix(framework-react): resolve docgen tsconfig per file

### DIFF
--- a/packages/framework-react/package.json
+++ b/packages/framework-react/package.json
@@ -55,12 +55,12 @@
     "@rollup/pluginutils": "^5.4.0",
     "@storybook/react": "^10.5.10",
     "@storybook/react-docgen-typescript-plugin": "^1.0.1",
-    "find-up": "^5.0.0",
     "magic-string": "^0.30.21",
     "react-docgen": "^8.0.3",
     "react-docgen-typescript": "^2.4.0",
     "resolve": "^1.22.12",
     "storybook-builder-rsbuild": "workspace:*",
+    "strip-json-comments": "^5.0.1",
     "tsconfig-paths": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/framework-react/src/loaders/react-docgen-loader.test.ts
+++ b/packages/framework-react/src/loaders/react-docgen-loader.test.ts
@@ -2,11 +2,15 @@
  * Code taken from https://github.com/storybookjs/storybook/tree/next/code/presets/react-webpack/src/loaders
  */
 
-import { describe, expect, it, rs } from '@rstest/core'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it, rs } from '@rstest/core'
 import * as docgenResolverActual from './docgen-resolver' with {
   rstest: 'importActual',
 }
-import { getReactDocgenImporter } from './react-docgen-loader'
+import reactDocgenLoader, {
+  getReactDocgenImporter,
+} from './react-docgen-loader'
 
 const { reactDocgenActual } = rs.hoisted(() => {
   return {
@@ -17,6 +21,7 @@ const { reactDocgenActual } = rs.hoisted(() => {
 const reactDocgenMock = rs.hoisted(() => {
   return {
     makeFsImporter: rs.fn().mockImplementation((fn) => fn),
+    parse: rs.fn().mockReturnValue([]),
   }
 })
 
@@ -37,7 +42,81 @@ rs.mock('react-docgen', () => {
   return {
     ...reactDocgenActual,
     makeFsImporter: reactDocgenMock.makeFsImporter,
+    parse: reactDocgenMock.parse,
   }
+})
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('reactDocgenLoader function', () => {
+  it('uses the referenced tsconfig that owns each file', async () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './apps/first' }, { path: './apps/second' }],
+      }),
+      'apps/first/tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@ui/props': ['./src/first-props.ts'],
+          },
+        },
+        include: ['src'],
+      }),
+      'apps/first/src/Button.tsx': 'export const Button = () => null',
+      'apps/first/src/first-props.ts': 'export interface Props {}',
+      'apps/second/tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@ui/props': ['./src/second-props.ts'],
+          },
+        },
+        include: ['src'],
+      }),
+      'apps/second/src/Button.tsx': 'export const Button = () => null',
+      'apps/second/src/second-props.ts': 'export interface Props {}',
+    })
+    const resourcePaths = [
+      join(dir, 'apps/first/src/Button.tsx'),
+      join(dir, 'apps/second/src/Button.tsx'),
+    ]
+    const importedPaths: string[] = []
+
+    reactDocgenResolverMock.defaultLookupModule.mockImplementation(
+      (filename: string) => filename,
+    )
+    reactDocgenMock.parse.mockImplementation(
+      (
+        _source: string,
+        options: {
+          filename: string
+          importer: (filename: string, basedir: string) => string
+        },
+      ) => {
+        importedPaths.push(
+          options.importer('@ui/props', dirname(options.filename)),
+        )
+        return []
+      },
+    )
+
+    for (const resourcePath of resourcePaths) {
+      await runLoader(resourcePath)
+    }
+
+    expect(importedPaths).toEqual([
+      join(dir, 'apps/first/src/first-props.ts'),
+      join(dir, 'apps/second/src/second-props.ts'),
+    ])
+  })
 })
 
 describe('getReactDocgenImporter function', () => {
@@ -65,3 +144,28 @@ describe('getReactDocgenImporter function', () => {
     expect(result).toBe(mappedFile)
   })
 })
+
+async function runLoader(resourcePath: string) {
+  await reactDocgenLoader.call(
+    {
+      async: () => rs.fn(),
+      getOptions: () => ({}),
+      resourcePath,
+    } as never,
+    'export const Button = () => null',
+    undefined,
+  )
+}
+
+function createTempProject(files: Record<string, string>) {
+  const dir = mkdtempSync(join(process.cwd(), '.tmp-react-docgen-loader-'))
+  tempDirs.push(dir)
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = join(dir, relativePath)
+    mkdirSync(dirname(fullPath), { recursive: true })
+    writeFileSync(fullPath, content, 'utf-8')
+  }
+
+  return dir
+}

--- a/packages/framework-react/src/loaders/react-docgen-loader.ts
+++ b/packages/framework-react/src/loaders/react-docgen-loader.ts
@@ -2,7 +2,7 @@
  * Code taken from https://github.com/storybookjs/storybook/tree/next/code/presets/react-webpack/src/loaders
  */
 
-import findUp from 'find-up'
+import { dirname } from 'node:path'
 import MagicString from 'magic-string'
 import type {
   Documentation,
@@ -18,6 +18,7 @@ import {
   parse,
   utils,
 } from 'react-docgen'
+import { findTsconfigPathForFile } from 'storybook/internal/common'
 import { logger } from 'storybook/internal/node-logger'
 import * as TsconfigPaths from 'tsconfig-paths'
 // @ts-expect-error can not reexport `LoaderContext` from @rsbuild/core
@@ -28,6 +29,7 @@ import {
   RESOLVE_EXTENSIONS,
   ReactDocgenResolveError,
 } from './docgen-resolver'
+import { getTsconfigPathsBaseDir } from './tsconfig-paths'
 
 const { getNameOrValue, isReactForwardRefCall } = utils
 
@@ -82,47 +84,6 @@ const defaultHandlers = Object.values(docgenHandlers).map((handler) => handler)
 const defaultResolver = new docgenResolver.FindExportedDefinitionsResolver()
 const handlers = [...defaultHandlers, actualNameHandler]
 
-let tsconfigPathsInitializeStatus:
-  | 'uninitialized'
-  | 'initializing'
-  | 'initialized' = 'uninitialized'
-
-let resolveTsconfigPathsInitialingPromise: (
-  value: void | PromiseLike<void>,
-) => void
-const tsconfigPathsInitialingPromise = new Promise<void>((resolve) => {
-  resolveTsconfigPathsInitialingPromise = resolve
-})
-
-const finishInitialization = () => {
-  resolveTsconfigPathsInitialingPromise()
-  tsconfigPathsInitializeStatus = 'initialized'
-}
-
-let matchPath: TsconfigPaths.MatchPath | undefined
-
-/**
- * Tsconfig filenames to try, in order.
- *
- * @see https://github.com/storybookjs/storybook/blob/3e12dfc040/code/presets/react-webpack/src/loaders/react-docgen-loader.ts#L86-L89
- */
-const TSCONFIG_CANDIDATES = [
-  'tsconfig.json',
-  'tsconfig.base.json',
-  'tsconfig.app.json',
-] as const
-
-const findTsconfigPath = async (cwd: string): Promise<string | undefined> => {
-  for (const candidate of TSCONFIG_CANDIDATES) {
-    const found = await findUp(candidate, { cwd })
-    if (found) {
-      return found
-    }
-  }
-
-  return undefined
-}
-
 export default async function reactDocgenLoader(
   this: LoaderContext<{ debug: boolean }>,
   source: string,
@@ -133,28 +94,8 @@ export default async function reactDocgenLoader(
   const options = this.getOptions() || {}
   const { debug = false } = options
 
-  if (tsconfigPathsInitializeStatus === 'uninitialized') {
-    tsconfigPathsInitializeStatus = 'initializing'
-    const tsconfigPath = await findTsconfigPath(process.cwd())
-    const tsconfig = TsconfigPaths.loadConfig(tsconfigPath)
-
-    if (tsconfig.resultType === 'success') {
-      logger.info('Using tsconfig paths for react-docgen')
-      matchPath = TsconfigPaths.createMatchPath(
-        tsconfig.absoluteBaseUrl,
-        tsconfig.paths,
-        ['browser', 'module', 'main'],
-      )
-    }
-
-    finishInitialization()
-  }
-
-  if (tsconfigPathsInitializeStatus === 'initializing') {
-    await tsconfigPathsInitialingPromise
-  }
-
   try {
+    const matchPath = createTsconfigMatchPath(this.resourcePath)
     const docgenResults = parse(source, {
       filename: this.resourcePath,
       resolver: defaultResolver,
@@ -226,4 +167,33 @@ export function getReactDocgenImporter(
 
     throw new ReactDocgenResolveError(filename)
   })
+}
+
+const matchPathByTsconfigPath = new Map<string, TsconfigPaths.MatchPath>()
+
+function createTsconfigMatchPath(filePath: string) {
+  const tsconfigPath = findTsconfigPathForFile(dirname(filePath), filePath)
+  if (!tsconfigPath) {
+    return undefined
+  }
+
+  const cached = matchPathByTsconfigPath.get(tsconfigPath)
+  if (cached) {
+    return cached
+  }
+
+  const tsconfig = TsconfigPaths.loadConfig(tsconfigPath)
+
+  if (tsconfig.resultType !== 'success') {
+    return undefined
+  }
+
+  logger.debug('Using tsconfig paths for react-docgen')
+  const matchPath = TsconfigPaths.createMatchPath(
+    getTsconfigPathsBaseDir(tsconfig.configFileAbsolutePath),
+    tsconfig.paths,
+    ['browser', 'module', 'main'],
+  )
+  matchPathByTsconfigPath.set(tsconfigPath, matchPath)
+  return matchPath
 }

--- a/packages/framework-react/src/loaders/tsconfig-paths.test.ts
+++ b/packages/framework-react/src/loaders/tsconfig-paths.test.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, describe, expect, it } from '@rstest/core'
+import { getTsconfigPathsBaseDir } from './tsconfig-paths'
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('getTsconfigPathsBaseDir', () => {
+  it('uses the parent config directory when paths are inherited without baseUrl', () => {
+    const dir = createTempProject({
+      'tsconfig.base.json': JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@tools/my-plugin': ['./tools/my-plugin/src'],
+            '@tools/my-plugin/*': ['./tools/my-plugin/src/*'],
+          },
+        },
+      }),
+      'test-app/tsconfig.json': JSON.stringify({
+        extends: '../tsconfig.base.json',
+        compilerOptions: {
+          module: 'esnext',
+        },
+      }),
+    })
+
+    expect(getTsconfigPathsBaseDir(join(dir, 'test-app/tsconfig.json'))).toBe(
+      dir,
+    )
+  })
+
+  it('uses the resolved parent baseUrl when the parent defines both baseUrl and paths', () => {
+    const dir = createTempProject({
+      'tsconfig.base.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@tools/my-plugin/*': ['./tools/my-plugin/src/*'],
+          },
+        },
+      }),
+      'test-app/tsconfig.json': JSON.stringify({
+        extends: '../tsconfig.base.json',
+      }),
+    })
+
+    expect(getTsconfigPathsBaseDir(join(dir, 'test-app/tsconfig.json'))).toBe(
+      dir,
+    )
+  })
+
+  it('uses the leaf directory when a single tsconfig defines paths without baseUrl', () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@lib/*': ['./src/lib/*'],
+          },
+        },
+      }),
+    })
+
+    expect(getTsconfigPathsBaseDir(join(dir, 'tsconfig.json'))).toBe(dir)
+  })
+
+  it('resolves an explicit baseUrl relative to the config that defined it', () => {
+    const dir = createTempProject({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: 'src',
+          paths: {
+            '@/*': ['./*'],
+          },
+        },
+      }),
+    })
+
+    expect(getTsconfigPathsBaseDir(join(dir, 'tsconfig.json'))).toBe(
+      join(dir, 'src'),
+    )
+  })
+
+  it('uses the leaf directory when the child defines its own paths', () => {
+    const dir = createTempProject({
+      'tsconfig.base.json': JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@tools/*': ['./tools/*'],
+          },
+        },
+      }),
+      'test-app/tsconfig.json': JSON.stringify({
+        extends: '../tsconfig.base.json',
+        compilerOptions: {
+          paths: {
+            '@app/*': ['./src/*'],
+          },
+        },
+      }),
+    })
+
+    expect(getTsconfigPathsBaseDir(join(dir, 'test-app/tsconfig.json'))).toBe(
+      join(dir, 'test-app'),
+    )
+  })
+})
+
+function createTempProject(files: Record<string, string>) {
+  const dir = mkdtempSync(join(tmpdir(), 'storybook-tsconfig-'))
+  tempDirs.push(dir)
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const fullPath = join(dir, relativePath)
+    mkdirSync(dirname(fullPath), { recursive: true })
+    writeFileSync(fullPath, content, 'utf-8')
+  }
+
+  return dir
+}

--- a/packages/framework-react/src/loaders/tsconfig-paths.ts
+++ b/packages/framework-react/src/loaders/tsconfig-paths.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import stripJsonComments from 'strip-json-comments'
+
+type TsconfigConfig = {
+  compilerOptions?: {
+    baseUrl?: unknown
+    paths?: unknown
+  }
+  extends?: unknown
+}
+
+type PathsBaseResolution = {
+  absoluteBaseUrl?: string
+  pathsBasePath?: string
+}
+
+/**
+ * Backport of Storybook's tsconfig paths base resolution. Replace this helper
+ * with the official export when the minimum Storybook version provides it.
+ *
+ * @see https://github.com/storybookjs/storybook/blob/aa5790bb3484153ce3e9fe409e0ab516c2853e58/code/core/src/common/utils/tsconfig.ts
+ */
+export const getTsconfigPathsBaseDir = (configPath: string): string => {
+  const normalizedConfigPath = resolve(configPath)
+  const resolved = resolvePathsBase(normalizedConfigPath, new Set())
+  return (
+    resolved.absoluteBaseUrl ??
+    resolved.pathsBasePath ??
+    dirname(normalizedConfigPath)
+  )
+}
+
+function resolvePathsBase(
+  configPath: string,
+  seen: Set<string>,
+): PathsBaseResolution {
+  const normalizedConfigPath = resolve(configPath)
+  if (seen.has(normalizedConfigPath)) {
+    return {}
+  }
+  seen.add(normalizedConfigPath)
+
+  const config = readTsconfigConfig(normalizedConfigPath)
+  if (!config) {
+    return {}
+  }
+
+  let inherited: PathsBaseResolution = {}
+  for (const extendsPath of getExtendsPaths(normalizedConfigPath, config)) {
+    const base = resolvePathsBase(extendsPath, seen)
+    inherited = {
+      absoluteBaseUrl: base.absoluteBaseUrl ?? inherited.absoluteBaseUrl,
+      pathsBasePath: base.pathsBasePath ?? inherited.pathsBasePath,
+    }
+  }
+
+  const ownBaseUrl = config.compilerOptions?.baseUrl
+  const ownPaths = config.compilerOptions?.paths
+
+  return {
+    absoluteBaseUrl:
+      typeof ownBaseUrl === 'string' && ownBaseUrl.length > 0
+        ? resolve(dirname(normalizedConfigPath), ownBaseUrl)
+        : inherited.absoluteBaseUrl,
+    pathsBasePath:
+      ownPaths !== undefined &&
+      ownPaths !== null &&
+      typeof ownPaths === 'object'
+        ? dirname(normalizedConfigPath)
+        : inherited.pathsBasePath,
+  }
+}
+
+function getExtendsPaths(configPath: string, config: TsconfigConfig) {
+  const rawExtends =
+    typeof config.extends === 'string'
+      ? [config.extends]
+      : Array.isArray(config.extends)
+        ? config.extends.filter(
+            (value): value is string => typeof value === 'string',
+          )
+        : []
+
+  return rawExtends.map((extendsPath) =>
+    resolveExtendsPath(configPath, extendsPath),
+  )
+}
+
+function resolveExtendsPath(configPath: string, extendsPath: string) {
+  const resolved = resolve(dirname(configPath), extendsPath)
+  if (existsSync(resolved)) {
+    return resolved
+  }
+
+  if (!resolved.endsWith('.json')) {
+    const withJson = `${resolved}.json`
+    if (existsSync(withJson)) {
+      return withJson
+    }
+  }
+
+  return resolved
+}
+
+function readTsconfigConfig(configPath: string): TsconfigConfig | undefined {
+  try {
+    const content = readFileSync(configPath, 'utf-8')
+    return JSON.parse(
+      stripJsonComments(content, { trailingCommas: true }),
+    ) as TsconfigConfig
+  } catch {
+    return undefined
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,6 @@ importers:
       '@storybook/react-docgen-typescript-plugin':
         specifier: ^1.0.1
         version: 1.0.1(typescript@5.9.3)(webpack@5.104.1)
-      find-up:
-        specifier: ^5.0.0
-        version: 5.0.0
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -281,6 +278,9 @@ importers:
       storybook-builder-rsbuild:
         specifier: workspace:*
         version: link:../builder-rsbuild
+      strip-json-comments:
+        specifier: ^5.0.1
+        version: 5.0.3
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -11630,6 +11630,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   style-loader@4.0.0:
     resolution: {integrity: sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==}
@@ -26977,6 +26981,8 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
+
+  strip-json-comments@5.0.3: {}
 
   style-loader@4.0.0(webpack@5.104.1(esbuild@0.28.0)):
     dependencies:


### PR DESCRIPTION
## Summary

- port Storybook's per-file React docgen tsconfig selection so solution-style project references use the tsconfig that owns each source file
- cache `tsconfig-paths` matchers by tsconfig path and preserve the upstream missing-config guard
- backfill Storybook's `getTsconfigPathsBaseDir` implementation for inherited `paths` without `baseUrl`
- replace the no-longer-used `find-up` dependency with upstream's `strip-json-comments` dependency

This ports upstream commits 6856e793, b69dd4c4, a20bc24e, and aa5790bb. The pinned Storybook 10.5.10 exports `findTsconfigPathForFile` but not `getTsconfigPathsBaseDir`, so the latter is faithfully backfilled locally until the minimum Storybook version exposes the official helper.

## Validation

- `pnpm exec biome check --write packages/framework-react/src/loaders/react-docgen-loader.ts packages/framework-react/src/loaders/react-docgen-loader.test.ts packages/framework-react/src/loaders/tsconfig-paths.ts packages/framework-react/src/loaders/tsconfig-paths.test.ts packages/framework-react/package.json`
- `pnpm exec rstest packages/framework-react/src/loaders/react-docgen-loader.test.ts packages/framework-react/src/loaders/tsconfig-paths.test.ts` (2 files, 8 tests passed)
- `pnpm check`
- `pnpm --filter storybook-react-rsbuild build`

Part of #544
