### PR TITLE
chore(skills): widen minify divergence note to user-owned JS minify

### DIFF
--- a/.agents/skills/storybook-check/manifest.json
+++ b/.agents/skills/storybook-check/manifest.json
@@ -59,7 +59,7 @@
       "intentionalDivergences": [
         "expressed as Rsbuild config instead of raw webpack config; also absorbs upstream preview/base-webpack.config.ts and presets/custom-webpack-preset.ts responsibilities",
         "build.test.esbuildMinify branch not ported: Rsbuild's output.minify.jsOptions only exposes the built-in SWC minimizer, no clean seam to swap in esbuild (mangle:false/keep_fnames ported in PR #549)",
-        "prod minify fragment is gated on the inherited rsbuild.config not setting output.minify: false — upstream minimizes unconditionally, but the inherited-config path (PR #538) is a local-only feature whose explicit opt-out must survive the merge (PR #549 review)"
+        "prod minify fragment is injected only when the inherited rsbuild.config has no JS minification customization (no minify: false, minify.js, or minify.jsOptions) — upstream minimizes unconditionally, but the inherited-config path (PR #538) is a local-only feature whose minify settings are user-owned (PR #549 review)"
       ]
     },
     {


### PR DESCRIPTION
Follow-up to #550: the #549 review loop generalized the prod minify injection gate from "skip on `output.minify: false`" to "inject only when the inherited config has no JS minification customization at all (no `minify: false`, `minify.js`, or `minify.jsOptions`)". Update the recorded intentional divergence to match.