### PR TITLE
chore(skills): record keep_fnames mangle divergence

### DIFF
--- a/.agents/skills/storybook-check/manifest.json
+++ b/.agents/skills/storybook-check/manifest.json
@@ -59,7 +59,8 @@
       "intentionalDivergences": [
         "expressed as Rsbuild config instead of raw webpack config; also absorbs upstream preview/base-webpack.config.ts and presets/custom-webpack-preset.ts responsibilities",
         "build.test.esbuildMinify branch not ported: Rsbuild's output.minify.jsOptions only exposes the built-in SWC minimizer, no clean seam to swap in esbuild (mangle:false/keep_fnames ported in PR #549)",
-        "prod minify fragment is injected only when the inherited rsbuild.config has no JS minification customization (no minify: false, minify.js, or minify.jsOptions) — upstream minimizes unconditionally, but the inherited-config path (PR #538) is a local-only feature whose minify settings are user-owned (PR #549 review)"
+        "prod minify fragment is injected only when the inherited rsbuild.config has no JS minification customization (no minify: false, minify.js, or minify.jsOptions) — upstream minimizes unconditionally, but the inherited-config path (PR #538) is a local-only feature whose minify settings are user-owned (PR #549 review)",
+        "prod minifier uses mangle: { keep_fnames, keep_classnames } instead of upstream's mangle: false — same name-preservation goal (docs titles, Show code), but local identifiers still mangle, ~26% smaller gzip; upstream's blanket mangle:false is 2016-era inertia (PR #549)"
       ]
     },
     {

--- a/.agents/skills/storybook-check/manifest.json
+++ b/.agents/skills/storybook-check/manifest.json
@@ -60,7 +60,7 @@
         "expressed as Rsbuild config instead of raw webpack config; also absorbs upstream preview/base-webpack.config.ts and presets/custom-webpack-preset.ts responsibilities",
         "build.test.esbuildMinify branch not ported: Rsbuild's output.minify.jsOptions only exposes the built-in SWC minimizer, no clean seam to swap in esbuild (mangle:false/keep_fnames ported in PR #549)",
         "prod minify fragment is injected only when the inherited rsbuild.config has no JS minification customization (no minify: false, minify.js, or minify.jsOptions) — upstream minimizes unconditionally, but the inherited-config path (PR #538) is a local-only feature whose minify settings are user-owned (PR #549 review)",
-        "prod minifier uses mangle: { keep_fnames, keep_classnames } instead of upstream's mangle: false — same name-preservation goal (docs titles, Show code), but local identifiers still mangle, ~26% smaller gzip; upstream's blanket mangle:false is 2016-era inertia (PR #549)"
+        "prod minifier uses mangle: { keep_fnames, keep_classnames } instead of upstream's mangle: false — same name-preservation goal (docs titles, Show code) with ~26% smaller gzip; known accepted boundary: `const X = class {}` binding-inferred names are still mangled (rare form, docgen displayName covers user source) (PR #549)"
       ]
     },
     {


### PR DESCRIPTION
Records the divergence approved in the #549 review loop: the prod minifier uses `mangle: { keep_fnames: true, keep_classnames: true }` instead of upstream's blanket `mangle: false` — same name-preservation goal, ~26% smaller gzip output.