### PR TITLE
chore(skills): record progress rebuild-reset divergence

### DIFF
--- a/.agents/skills/storybook-check/manifest.json
+++ b/.agents/skills/storybook-check/manifest.json
@@ -46,7 +46,8 @@
       "local": "packages/builder-rsbuild/src/index.ts",
       "intentionalDivergences": [
         "builder entry drives Rsbuild's createRsbuild/dev-server lifecycle instead of webpack compiler + webpack-dev-middleware; compare behavior (start/build/bail/corePresets contract), not structure",
-        "PREVIEW_BUILDER_PROGRESS ported without the modulesCount cache loop or progress.modules counts — Rspack's ProgressPlugin has no modulesCount estimation option and nothing consumes the cached value (PR #553)"
+        "PREVIEW_BUILDER_PROGRESS ported without the modulesCount cache loop or progress.modules counts — Rspack's ProgressPlugin has no modulesCount estimation option and nothing consumes the cached value (PR #553)",
+        "progress value resets between compilations so rebuilds report real progress — upstream's monotonic clamp never resets and pins every rebuild at 1 (deliberate fix over upstream, PR #553)"
       ]
     },
     {


### PR DESCRIPTION
Records the deliberate divergence added in #553's review loop: the progress value resets between compilations so rebuilds report real progress — upstream's monotonic clamp never resets and pins every rebuild at 1.