### PR TITLE
fix(builder-rsbuild): align module rules and resolution with upstream

### DIFF
--- a/.agents/skills/storybook-check/manifest.json
+++ b/.agents/skills/storybook-check/manifest.json
@@ -63,7 +63,11 @@
         "expressed as Rsbuild config instead of raw webpack config; also absorbs upstream preview/base-webpack.config.ts and presets/custom-webpack-preset.ts responsibilities",
         "build.test.esbuildMinify branch not ported: Rsbuild's output.minify.jsOptions only exposes the built-in SWC minimizer, no clean seam to swap in esbuild (mangle:false/keep_fnames ported in PR #549)",
         "prod minify fragment is injected only when the inherited rsbuild.config has no JS minification customization (no minify: false, minify.js, or minify.jsOptions) — upstream minimizes unconditionally, but the inherited-config path (PR #538) is a local-only feature whose minify settings are user-owned (PR #549 review)",
-        "prod minifier uses mangle: { keep_fnames, keep_classnames } instead of upstream's mangle: false — same name-preservation goal (docs titles, Show code) with ~26% smaller gzip; known accepted boundary: `const X = class {}` binding-inferred names are still mangled (rare form, docgen displayName covers user source) (PR #549)"
+        "prod minifier uses mangle: { keep_fnames, keep_classnames } instead of upstream's mangle: false — same name-preservation goal (docs titles, Show code) with ~26% smaller gzip; known accepted boundary: `const X = class {}` binding-inferred names are still mangled (rare form, docgen displayName covers user source) (PR #549)",
+        "SWC env.targets default comes from Rsbuild's browserslist chain (.browserslistrc / overrideBrowserslist) instead of upstream's hardcoded chrome 100/safari 15/firefox 91 floor — upstream hardcodes only because builder-webpack5 has no browserslist integration; explicit user env.targets wins identically on both sides (PR #556)",
+        "B1/B11 module rules use Rsbuild's addRules() API, whose prepend ordering keeps user-provided rules later in the merged config so they retain upstream-equivalent precedence (PR #556)",
+        "fallback defaults retain the builder's existing browser polyfills while adding upstream's crypto: false, and merge user fallback values last to fix the local ??= all-or-nothing bug while preserving user precedence (PR #556)",
+        "optimization.sideEffects: true is applied through Rsbuild's tools.rspack hook instead of raw webpack config (PR #556)"
       ]
     },
     {

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -417,18 +417,34 @@ export default async (
         config.env.bugfixes = true
       },
       rspack: (config, { addRules, appendRules, rspack, mergeConfig }) => {
-        addRules({
-          test: /\.stories\.([tj])sx?$|(stories|story)\.mdx$/,
-          exclude: /node_modules/,
-          enforce: 'post',
-          use: [
-            {
-              loader: require.resolve(
-                'storybook-builder-rsbuild/loaders/export-order-loader',
-              ),
+        addRules([
+          {
+            test: /\.stories\.([tj])sx?$|(stories|story)\.mdx$/,
+            exclude: /node_modules/,
+            enforce: 'post',
+            use: [
+              {
+                loader: require.resolve(
+                  'storybook-builder-rsbuild/loaders/export-order-loader',
+                ),
+              },
+            ],
+          },
+          {
+            test: /\.m?js$/,
+            type: 'javascript/auto',
+          },
+          {
+            test: /\.m?js$/,
+            resolve: {
+              fullySpecified: false,
             },
-          ],
-        })
+          },
+          {
+            test: /\.md$/,
+            type: 'asset/source',
+          },
+        ])
 
         // Disable warning for dynamic requires
         config.module ??= {}

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -507,7 +507,7 @@ export default async (
 
         config.optimization ??= {}
         config.optimization.runtimeChunk = true
-        config.optimization.sideEffects = true
+        config.optimization.sideEffects ??= true
         config.optimization.usedExports = options.build?.test
           ?.disableTreeShaking
           ? false

--- a/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
+++ b/packages/builder-rsbuild/src/preview/iframe-rsbuild.config.ts
@@ -369,12 +369,14 @@ export default async (
     },
     source: {
       define: {
+        'process.env': `(${JSON.stringify(envs)})`,
         ...stringifyProcessEnvs(envs),
         'process.env.NODE_ENV': JSON.stringify(
           features?.developmentModeForBuild && isProd
             ? 'development'
             : process.env.NODE_ENV,
         ),
+        ...contentFromConfig.source?.define,
       },
     },
     // Rsbuild v1 compatible: `performance.chunkSplit` is deprecated in Rsbuild v2, use top-level `splitChunks` instead.
@@ -412,9 +414,17 @@ export default async (
     ].filter(Boolean),
     tools: {
       swc: (config) => {
+        const shouldRemoveBugfixes =
+          features &&
+          'babelRemoveBugfixes' in features &&
+          features.babelRemoveBugfixes
+
         config.env ??= {}
-        // Ensure the deconstruction of the in-play function in parameters.
-        config.env.bugfixes = true
+        if (!shouldRemoveBugfixes) {
+          // Transpile broken syntax to the closest non-broken modern syntax so parameter
+          // destructuring in Safari does not break play-function context detection.
+          config.env.bugfixes ??= true
+        }
       },
       rspack: (config, { addRules, appendRules, rspack, mergeConfig }) => {
         addRules([
@@ -460,6 +470,7 @@ export default async (
             ...builtInResolveExtensions,
           ]),
         )
+        config.resolve.modules ??= ['node_modules'].concat(envs.NODE_PATH || [])
         // `'...'` is Rspack's sentinel for "keep the default conditions" — without it the
         // defaults are replaced rather than extended.
         // @see https://github.com/storybookjs/storybook/blob/3e12dfc040/code/builders/builder-webpack5/src/preview/base-webpack.config.ts#L98-L104
@@ -482,7 +493,8 @@ export default async (
         ]
 
         config.resolve ??= {}
-        config.resolve.fallback ??= {
+        config.resolve.fallback = {
+          crypto: false,
           stream: false,
           path: require.resolve('path-browserify'),
           assert: require.resolve('browser-assert'),
@@ -490,10 +502,12 @@ export default async (
           url: require.resolve('url'),
           fs: false,
           constants: require.resolve('constants-browserify'),
+          ...config.resolve.fallback,
         }
 
         config.optimization ??= {}
         config.optimization.runtimeChunk = true
+        config.optimization.sideEffects = true
         config.optimization.usedExports = options.build?.test
           ?.disableTreeShaking
           ? false

--- a/packages/builder-rsbuild/tests/fixtures/rsbuild.config.ts
+++ b/packages/builder-rsbuild/tests/fixtures/rsbuild.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from '@rsbuild/core'
 
 export default defineConfig({
   source: {
+    define: {
+      'process.env.STORYBOOK_ENV': JSON.stringify('user-defined'),
+    },
     entry: {
       custom: ['./user-defined-entry.js'],
     },

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -387,6 +387,17 @@ describe('iframe-rsbuild.config', () => {
     expect(rspackConfig.optimization.sideEffects).toBe(true)
   })
 
+  it.each([false, 'flag'] as const)(
+    'preserves user-provided side-effects analysis value %s',
+    async (sideEffects) => {
+      const { rspackConfig } = await runRspackTool(false, [], {
+        optimization: { sideEffects },
+      })
+
+      expect(rspackConfig.optimization.sideEffects).toBe(sideEffects)
+    },
+  )
+
   it('merges fallback defaults without overriding user values', async () => {
     const { rspackConfig } = await runRspackTool(false, [], {
       resolve: {

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -294,6 +294,38 @@ describe('iframe-rsbuild.config', () => {
     expect(storiesModule).not.toContain('const importPipeline =')
   })
 
+  it('handles bare Markdown imports as source assets', async () => {
+    const { addRules } = await runRspackTool(false)
+
+    expect(addRules).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        {
+          test: /\.md$/,
+          type: 'asset/source',
+        },
+      ]),
+    )
+  })
+
+  it('relaxes strict ESM resolution for JavaScript modules', async () => {
+    const { addRules } = await runRspackTool(false)
+
+    expect(addRules).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        {
+          test: /\.m?js$/,
+          type: 'javascript/auto',
+        },
+        {
+          test: /\.m?js$/,
+          resolve: {
+            fullySpecified: false,
+          },
+        },
+      ]),
+    )
+  })
+
   it('appends raw query fallback rule for asset/source imports', async () => {
     const { appendRules } = await runRspackTool(false)
 

--- a/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
+++ b/packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts
@@ -69,7 +69,14 @@ const createOptions = (
     ],
     ['framework', {}],
     ['frameworkOptions', { renderer: '@storybook/react', legacyRootApi: true }],
-    ['env', { STORYBOOK_ENV: 'development' }],
+    [
+      'env',
+      {
+        STORYBOOK_ENV: 'development',
+        STORYBOOK_SECOND_ENV: 'defined-per-key',
+        NODE_PATH: ['/workspace/shared', '/workspace/generated'],
+      },
+    ],
     ['logLevel', 'info'],
     ['previewHead', '<!-- head -->'],
     ['previewBody', '<!-- body -->'],
@@ -142,6 +149,24 @@ describe('iframe-rsbuild.config', () => {
 
     expect(config.source?.entry).toEqual({
       main: [storybookEntries[0], expectedDynamicEntry],
+    })
+  })
+
+  it('defines process.env as an object while preserving per-key user defines', async () => {
+    const { options } = createOptions()
+
+    const config = await createIframeRsbuildConfig(
+      options as RsbuildBuilderOptions,
+    )
+
+    expect(config.source?.define).toMatchObject({
+      'process.env': `(${JSON.stringify({
+        STORYBOOK_ENV: 'development',
+        STORYBOOK_SECOND_ENV: 'defined-per-key',
+        NODE_PATH: ['/workspace/shared', '/workspace/generated'],
+      })})`,
+      'process.env.STORYBOOK_ENV': JSON.stringify('user-defined'),
+      'process.env.STORYBOOK_SECOND_ENV': JSON.stringify('defined-per-key'),
     })
   })
 
@@ -224,6 +249,7 @@ describe('iframe-rsbuild.config', () => {
   const runRspackTool = async (
     lazyCompilation: LazyCompilationOption | 'unset',
     staticDirs: unknown = [],
+    baseConfig: Rspack.Configuration = {},
   ) => {
     const { options } = createOptions(
       lazyCompilation,
@@ -237,7 +263,6 @@ describe('iframe-rsbuild.config', () => {
     const rspackTool = config.tools?.rspack
     expect(typeof rspackTool).toBe('function')
 
-    const baseConfig = {} as any
     const addRules = rs.fn()
     const appendRules = rs.fn()
     let virtualModules: Record<string, string> = {}
@@ -259,6 +284,26 @@ describe('iframe-rsbuild.config', () => {
     }) as any
 
     return { rspackConfig: result, addRules, appendRules, virtualModules }
+  }
+
+  const runSwcTool = async (
+    swcConfig: Record<string, any>,
+    babelRemoveBugfixes = false,
+  ) => {
+    const { options } = createOptions()
+    options.features = {
+      ...options.features,
+      babelRemoveBugfixes,
+    }
+    const config = await createIframeRsbuildConfig(
+      options as RsbuildBuilderOptions,
+    )
+
+    const swcTool = config.tools?.swc
+    expect(typeof swcTool).toBe('function')
+    ;(swcTool as any)(swcConfig)
+
+    return swcConfig
   }
 
   it('uses entries:false when lazyCompilation is unset', async () => {
@@ -324,6 +369,74 @@ describe('iframe-rsbuild.config', () => {
         },
       ]),
     )
+  })
+
+  it('resolves modules from NODE_PATH', async () => {
+    const { rspackConfig } = await runRspackTool(false)
+
+    expect(rspackConfig.resolve.modules).toEqual([
+      'node_modules',
+      '/workspace/shared',
+      '/workspace/generated',
+    ])
+  })
+
+  it('enables side-effects analysis in development', async () => {
+    const { rspackConfig } = await runRspackTool(false)
+
+    expect(rspackConfig.optimization.sideEffects).toBe(true)
+  })
+
+  it('merges fallback defaults without overriding user values', async () => {
+    const { rspackConfig } = await runRspackTool(false, [], {
+      resolve: {
+        fallback: {
+          assert: 'user-assert',
+          custom: 'user-custom',
+        },
+      },
+    })
+
+    expect(rspackConfig.resolve.fallback).toMatchObject({
+      crypto: false,
+      stream: false,
+      path: expect.any(String),
+      assert: 'user-assert',
+      util: expect.any(String),
+      url: expect.any(String),
+      fs: false,
+      constants: expect.any(String),
+      custom: 'user-custom',
+    })
+  })
+
+  it('preserves a user-provided SWC bugfixes value', async () => {
+    const swcConfig = await runSwcTool({
+      env: {
+        targets: ['chrome >= 100'],
+        bugfixes: false,
+      },
+    })
+
+    expect(swcConfig.env).toEqual({
+      targets: ['chrome >= 100'],
+      bugfixes: false,
+    })
+  })
+
+  it('omits the SWC bugfixes default when the feature opts out', async () => {
+    const swcConfig = await runSwcTool(
+      {
+        env: {
+          targets: ['chrome >= 100'],
+        },
+      },
+      true,
+    )
+
+    expect(swcConfig.env).toEqual({
+      targets: ['chrome >= 100'],
+    })
   })
 
   it('appends raw query fallback rule for asset/source imports', async () => {

--- a/sandboxes/react-18/src/env.d.ts
+++ b/sandboxes/react-18/src/env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="@rsbuild/core/types" />
 
+declare module '*.md' {
+  const content: string
+  export default content
+}
+
 declare module '*.md?raw' {
   const content: string
   export default content

--- a/sandboxes/react-18/src/stories/RawImport.stories.tsx
+++ b/sandboxes/react-18/src/stories/RawImport.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import exampleMarkdown from './assets/example.md?raw'
+import bareMarkdown from './assets/example.md'
+import rawMarkdown from './assets/example.md?raw'
 
 /**
  * A simple component that displays raw markdown content.
- * This story tests the `?raw` import functionality.
  */
 const RawMarkdownDisplay = ({ content }: { content: string }) => {
   return (
@@ -37,6 +37,15 @@ type Story = StoryObj<typeof RawMarkdownDisplay>
  */
 export const MarkdownRaw: Story = {
   args: {
-    content: exampleMarkdown,
+    content: rawMarkdown,
+  },
+}
+
+/**
+ * Demonstrates importing a markdown file as a raw string without a resource query.
+ */
+export const MarkdownBare: Story = {
+  args: {
+    content: bareMarkdown,
   },
 }


### PR DESCRIPTION
## Summary

- align preview module handling with current builder-webpack5 behavior
- align environment, module resolution, fallback, and optimization defaults while preserving user precedence
- honor SWC bugfix configuration and opt-out semantics without overriding Rsbuild's browserslist-derived targets

## Upstream alignment

| Finding | Port | Coverage |
| --- | --- | --- |
| B1 | Add a bare `.md` `asset/source` rule while retaining the existing `?raw` rule ([storybookjs/storybook#14281](https://redirect.github.com/storybookjs/storybook/pull/14281)) | `handles bare Markdown imports as source assets`; React 18 sandbox bare Markdown story |
| B6 | Define `process.env` as a whole object while retaining per-key defines and user overrides ([storybookjs/storybook#33383](https://redirect.github.com/storybookjs/storybook/pull/33383)) | `defines process.env as an object while preserving per-key user defines` |
| B7 | Add `NODE_PATH` entries to default `resolve.modules` ([storybookjs/storybook#14191](https://redirect.github.com/storybookjs/storybook/pull/14191)) | `resolves modules from NODE_PATH` |
| B8 | Enable `optimization.sideEffects` in development ([storybookjs/storybook#13808](https://redirect.github.com/storybookjs/storybook/pull/13808)) | `enables side-effects analysis in development` |
| B9 | Add `crypto: false` and merge fallback defaults beneath user values ([storybookjs/storybook#14914](https://redirect.github.com/storybookjs/storybook/pull/14914)) | `merges fallback defaults without overriding user values` |
| B11 | Relax strict ESM handling for `.js` and `.mjs` modules ([storybookjs/storybook#18534](https://redirect.github.com/storybookjs/storybook/pull/18534)) | `relaxes strict ESM resolution for JavaScript modules` |
| B12 | Preserve explicit SWC `bugfixes` values and honor `features.babelRemoveBugfixes` ([storybookjs/storybook#35266](https://redirect.github.com/storybookjs/storybook/pull/35266)) | `preserves a user-provided SWC bugfixes value`; `omits the SWC bugfixes default when the feature opts out` |

## Rsbuild adaptations

- B1/B11 use Rsbuild's `addRules` API. Builder rules are prepended, so user rules remain later in the merged config and retain precedence.
- B6 spreads loaded user `source.define` values after builder defaults because this integration passes fragments through `mergeRsbuildConfig` rather than applying a later webpack config hook.
- B7 uses nullish defaulting so an explicit user `resolve.modules` value remains authoritative; the default shape otherwise matches upstream.
- B9 retains this builder's existing browser polyfill fallbacks, adds upstream's `crypto: false`, and spreads user values last.
- B12 intentionally does not add upstream's fixed `chrome 100`, `safari 15`, and `firefox 91` targets. Rsbuild derives SWC `env.targets` from browserslist and `output.overrideBrowserslist`; overriding them here would bypass that contract. A separate product decision is needed before changing target ownership.

## Validation

- `pnpm exec biome check --write` on all touched files
- `pnpm exec rstest packages/builder-rsbuild/tests/preview/iframe-rsbuild.config.test.ts` (29 tests)
- `pnpm exec rstest packages/builder-rsbuild` (10 files, 90 tests)
- `pnpm check`
- `pnpm --filter storybook-builder-rsbuild build`
- `pnpm --filter @sandboxes/react-18 build:storybook`
