### PR TITLE
fix(framework-react): align alias, RN docgen remap, and feature types

### DIFF
--- a/.agents/skills/storybook-check/manifest.json
+++ b/.agents/skills/storybook-check/manifest.json
@@ -150,7 +150,8 @@
       "local": "packages/framework-react/src/preset.ts",
       "intentionalDivergences": [
         "core expressed as an async PresetProperty that reads frameworkOptions and forwards frameworkOptions.builder as builder options — upstream made core a static object (PR #34260), but iframe-rsbuild.config.ts consumes builderOptions.lazyCompilation/fsCache so the function form is retained (repo-wide idiom across all framework packages)",
-        "builder/renderer specifiers wrapped in fileURLToPath — Rsbuild presets take paths, not file:// URLs (repo-wide idiom)"
+        "builder/renderer specifiers wrapped in fileURLToPath — Rsbuild presets take paths, not file:// URLs (repo-wide idiom)",
+        "@storybook/react alias is injected through rsbuildFinal with a framework-local createRequire resolution and merged before the inherited config so explicit user aliases win — upstream injects it in the webpack preset before user webpackFinal (upstream PR #18461)"
       ]
     },
     {
@@ -191,7 +192,9 @@
       "local": null,
       "reviewWith": "packages/framework-react",
       "note": "Vite twin of the react-docgen port; the port source is code/presets/react-webpack/src/loaders/react-docgen-loader.ts. Review only for docgen behaviors the webpack twin lacks.",
-      "intentionalDivergences": []
+      "intentionalDivergences": [
+        "react-native -> react-native-web importer remap lives in packages/framework-react/src/loaders/react-docgen-loader.ts because the local loader serves both upstream docgen implementations (upstream PR #31324)"
+      ]
     },
     {
       "upstream": "code/frameworks/react-vite/src/plugins/docgen-resolver.ts",

--- a/packages/builder-rsbuild/src/types.test.ts
+++ b/packages/builder-rsbuild/src/types.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@rstest/core'
+import type { StorybookConfigRsbuild } from './types'
+
+const features = {
+  experimentalTestSyntax: true,
+  babelRemoveBugfixes: true,
+} satisfies NonNullable<StorybookConfigRsbuild['features']>
+
+describe('StorybookConfigRsbuild', () => {
+  it('accepts builder feature flags', () => {
+    expect(features).toEqual({
+      experimentalTestSyntax: true,
+      babelRemoveBugfixes: true,
+    })
+  })
+})

--- a/packages/builder-rsbuild/src/types.ts
+++ b/packages/builder-rsbuild/src/types.ts
@@ -34,6 +34,22 @@ export type RsbuildFinal = (
 export type StorybookConfigRsbuild = {
   rsbuildFinal?: RsbuildFinal
   webpackAddons?: StorybookConfigRaw['addons']
+  features?: StorybookConfigRaw['features'] & {
+    /**
+     * Enable the experimental `.test` function in CSF Next
+     *
+     * @see https://storybook.js.org/docs/api/main-config/main-config-features#experimentaltestsyntax
+     */
+    experimentalTestSyntax?: boolean
+
+    /**
+     * Remove the `bugfixes` option from `@babel/preset-env`. This is required when using Babel 8 and when
+     * Storybook fails to detect your Babel version.
+     *
+     * @default false
+     */
+    babelRemoveBugfixes?: boolean
+  }
 }
 
 export type BuilderOptions = {

--- a/packages/framework-react/src/loaders/react-docgen-loader.test.ts
+++ b/packages/framework-react/src/loaders/react-docgen-loader.test.ts
@@ -143,6 +143,25 @@ describe('getReactDocgenImporter function', () => {
     const result = (imported as any)(filename, basedir)
     expect(result).toBe(mappedFile)
   })
+
+  it('remaps the React Native entry to React Native Web', () => {
+    const dir = createTempProject({
+      'node_modules/react-native-web/dist/index.js': '',
+    })
+    const reactNativeEntry = join(dir, 'node_modules/react-native/index.js')
+    const reactNativeWebEntry = join(
+      dir,
+      'node_modules/react-native-web/dist/index.js',
+    )
+    const imported = getReactDocgenImporter(undefined)
+    reactDocgenResolverMock.defaultLookupModule.mockReturnValue(
+      reactNativeEntry,
+    )
+
+    const result = (imported as any)('react-native', dir)
+
+    expect(result).toBe(reactNativeWebEntry)
+  })
 })
 
 async function runLoader(resourcePath: string) {

--- a/packages/framework-react/src/loaders/react-docgen-loader.ts
+++ b/packages/framework-react/src/loaders/react-docgen-loader.ts
@@ -2,7 +2,8 @@
  * Code taken from https://github.com/storybookjs/storybook/tree/next/code/presets/react-webpack/src/loaders
  */
 
-import { dirname } from 'node:path'
+import { existsSync } from 'node:fs'
+import { dirname, sep } from 'node:path'
 import MagicString from 'magic-string'
 import type {
   Documentation,
@@ -161,6 +162,17 @@ export function getReactDocgenImporter(
 
     const result = defaultLookupModule(mappedFilenameByPaths, basedir)
 
+    if (result.includes(`${sep}react-native${sep}index.js`)) {
+      const replaced = result.replace(
+        `${sep}react-native${sep}index.js`,
+        `${sep}react-native-web${sep}dist${sep}index.js`,
+      )
+      if (existsSync(replaced)) {
+        if (RESOLVE_EXTENSIONS.find((ext) => result.endsWith(ext))) {
+          return replaced
+        }
+      }
+    }
     if (RESOLVE_EXTENSIONS.find((ext) => result.endsWith(ext))) {
       return result
     }

--- a/packages/framework-react/src/preset.test.ts
+++ b/packages/framework-react/src/preset.test.ts
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
 import type { RsbuildConfig } from '@rsbuild/core'
 import { describe, expect, it } from '@rstest/core'
 import { rsbuildFinal } from './preset'
+
+const require = createRequire(import.meta.url)
 
 type RsbuildFinalOptions = Parameters<typeof rsbuildFinal>[1]
 
@@ -13,6 +16,27 @@ const createOptions = (developmentModeForBuild: boolean) =>
   }) as unknown as RsbuildFinalOptions
 
 describe('rsbuildFinal', () => {
+  it('aliases the framework-resolved renderer without overriding users', async () => {
+    const defaultResult = await rsbuildFinal({}, createOptions(false))
+    const userResult = await rsbuildFinal(
+      {
+        resolve: {
+          alias: {
+            '@storybook/react': '/user/storybook-react',
+          },
+        },
+      },
+      createOptions(false),
+    )
+
+    expect(defaultResult.resolve?.alias).toMatchObject({
+      '@storybook/react': require.resolve('@storybook/react'),
+    })
+    expect(userResult.resolve?.alias).toMatchObject({
+      '@storybook/react': '/user/storybook-react',
+    })
+  })
+
   it('adds a development NODE_ENV define when the feature is enabled', async () => {
     const config: RsbuildConfig = {
       source: {
@@ -30,11 +54,11 @@ describe('rsbuildFinal', () => {
     })
   })
 
-  it('leaves the config unchanged when the feature is disabled', async () => {
+  it('does not add a development NODE_ENV define when disabled', async () => {
     const disabledConfig: RsbuildConfig = {}
 
-    await expect(
-      rsbuildFinal(disabledConfig, createOptions(false)),
-    ).resolves.toBe(disabledConfig)
+    const result = await rsbuildFinal(disabledConfig, createOptions(false))
+
+    expect(result.source?.define?.['process.env.NODE_ENV']).toBeUndefined()
   })
 })

--- a/packages/framework-react/src/preset.ts
+++ b/packages/framework-react/src/preset.ts
@@ -1,13 +1,28 @@
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { mergeRsbuildConfig } from '@rsbuild/core'
 import type { PresetProperty } from 'storybook/internal/types'
 import { rsbuildFinalDocs } from './react-docs'
 import type { FrameworkOptions, StorybookConfig } from './types'
 
+const require = createRequire(import.meta.url)
+
 export const rsbuildFinal: NonNullable<
   StorybookConfig['rsbuildFinal']
 > = async (config, options) => {
-  const finalConfig = await rsbuildFinalDocs(config, options)
+  const finalConfig = await rsbuildFinalDocs(
+    mergeRsbuildConfig(
+      {
+        resolve: {
+          alias: {
+            '@storybook/react': require.resolve('@storybook/react'),
+          },
+        },
+      },
+      config,
+    ),
+    options,
+  )
 
   if (options.features?.developmentModeForBuild) {
     return mergeRsbuildConfig(finalConfig, {

--- a/packages/framework-react/src/types.test.ts
+++ b/packages/framework-react/src/types.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@rstest/core'
+import type { StorybookConfig } from './types'
+
+const features = {
+  experimentalTestSyntax: true,
+  babelRemoveBugfixes: true,
+} satisfies NonNullable<StorybookConfig['features']>
+
+describe('StorybookConfig', () => {
+  it('accepts React framework feature flags', () => {
+    expect(features).toEqual({
+      experimentalTestSyntax: true,
+      babelRemoveBugfixes: true,
+    })
+  })
+})

--- a/packages/framework-react/src/types.ts
+++ b/packages/framework-react/src/types.ts
@@ -57,6 +57,14 @@ type StorybookConfigFramework = {
           options: BuilderOptions
         }
   }
+  features?: StorybookConfigBase['features'] & {
+    /**
+     * Enable the experimental `.test` function in CSF Next
+     *
+     * @see https://storybook.js.org/docs/api/main-config/main-config-features#experimentaltestsyntax
+     */
+    experimentalTestSyntax?: boolean
+  }
   typescript?: Partial<
     TypescriptOptionsBase & TypescriptOptionsBuilder & TypescriptOptionsReact
   >


### PR DESCRIPTION
## Summary

- resolve `@storybook/react` from the framework package while preserving user aliases
- remap React Native imports to React Native Web during react-docgen resolution
- expose the current React and builder feature flags in `main.ts` config types
- record the Rsbuild-specific ownership and merge adaptations in the upstream-check manifest

## Upstream alignment

| Finding | Port | Coverage |
| --- | --- | --- |
| R1 | Add the framework-resolved `@storybook/react` alias for non-hoisted and Yarn PnP installs ([storybookjs/storybook#18461](https://redirect.github.com/storybookjs/storybook/pull/18461)) | `aliases the framework-resolved renderer without overriding users` |
| R2 | Remap a resolved `react-native/index.js` import to an available `react-native-web/dist/index.js` entry for docgen ([storybookjs/storybook#31324](https://redirect.github.com/storybookjs/storybook/pull/31324)) | `remaps the React Native entry to React Native Web`; React Native Web sandbox build |
| R3 | Declare `experimentalTestSyntax` from [storybookjs/storybook#32455](https://redirect.github.com/storybookjs/storybook/pull/32455) and the later `babelRemoveBugfixes` builder flag from [storybookjs/storybook#35266](https://redirect.github.com/storybookjs/storybook/pull/35266) | `accepts builder feature flags`; `accepts React framework feature flags` |

## Rsbuild adaptations

- R1 is implemented in `rsbuildFinal` with a framework-local `createRequire` resolution. The alias default is merged before the inherited Rsbuild config, matching upstream's preset-before-user-`webpackFinal` precedence while also preserving inherited user aliases.
- R2's upstream implementation lives in the React Vite docgen plugin. The local webpack-style loader serves both upstream docgen twins, so the remap is grafted there without changing the shared resolver.
- R3 follows current upstream ownership: both flags are exposed by the builder config type, while the React framework type additionally declares `experimentalTestSyntax`. There is no semantic divergence.

## Validation

- `pnpm exec biome check --write` on all 9 touched files
- manifest JSON parse validation
- `pnpm exec rstest packages/framework-react packages/builder-rsbuild` (16 files, 117 tests)
- `pnpm check`
- `pnpm --filter storybook-builder-rsbuild build`
- `pnpm --filter storybook-react-rsbuild build`
- `pnpm --filter @sandboxes/react-native-web build:storybook`
