### PR TITLE
feat(framework-vue3): support docgen framework option and public types

### DIFF
--- a/.agents/skills/storybook-check/manifest.json
+++ b/.agents/skills/storybook-check/manifest.json
@@ -231,14 +231,18 @@
     {
       "upstream": "code/frameworks/vue3-vite/src/types.ts",
       "local": "packages/framework-vue3/src/types.ts",
-      "intentionalDivergences": []
+      "intentionalDivergences": [
+        "public VueDocgenInfo and VueDocgenInfoEntry declarations are local ComponentDoc-based equivalents because pinned @storybook/vue3 does not export upstream's types; vue-component-meta metadata resolves to never and remains deferred with V2/issue #544"
+      ]
     },
     {
       "upstream": "code/frameworks/vue3-vite/src/docgen/options.ts",
       "local": null,
       "reviewWith": "packages/framework-vue3",
-      "note": "Part of upstream's docgen-server migration (vue-docgen-api deprecation, experimentalDocgenServer feature flag). Deferred on issue #544 until @storybook/vue3 exports the docgen engines. Review for the option-resolution contract (docgen: false | true | string | object) that framework-vue3 will need when the migration lands.",
-      "intentionalDivergences": []
+      "note": "Part of upstream's docgen-server migration (vue-docgen-api deprecation, experimentalDocgenServer feature flag). The docgen-server portion remains deferred on issue #544 until @storybook/vue3 exports the required contracts.",
+      "intentionalDivergences": [
+        "docgen option resolution is folded into framework-preset-vue3.ts instead of a separate module: false disables the loader while undefined, true, and vue-docgen-api retain the existing vue-docgen-api loader"
+      ]
     },
     {
       "upstream": "code/frameworks/vue3-vite/src/docgen/preset.ts",
@@ -259,8 +263,10 @@
       "upstream": "code/frameworks/vue3-vite/src/plugins/vue-component-meta.ts",
       "local": null,
       "reviewWith": "packages/framework-vue3",
-      "note": "Alternative docgen backend (vue-component-meta) with a vite-specific implementation. Review whether the capability or its options should have an Rsbuild parallel in framework-vue3.",
-      "intentionalDivergences": []
+      "note": "Alternative docgen backend (vue-component-meta) with a Vite-specific implementation. The Rsbuild engine remains deferred with V2 on issue #544.",
+      "intentionalDivergences": [
+        "docgen option accepts vue-component-meta string/object selectors for upstream config portability, but logs a warning and falls back to vue-docgen-api because the vue-component-meta engine remains deferred with V2/issue #544"
+      ]
     },
     {
       "upstream": "code/frameworks/vue3-vite/src/plugins/vue-template.ts",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,6 @@ When working on code in some specific package, use the Read tool to load that pa
 - Use **Biome** for formatting and linting (indentation: 2 spaces, single quotes, minimal semicolons).
 - Use **Rstest** for unit testing.
 - Follow the **kebab-case** convention for directories, filenames, and package names.
-- Use explicit `.ts`/`.tsx` extensions.
 - Colocate sandbox helpers with their owning packages.
 - Update relevant `sandboxes/` when adding or modifying features.
 - After any `rebase`, `merge`, or `stash pop` that changes dependency files (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.npmrc`), run `pnpm install` before any validation command (`build`, `test`, `e2e`, `lint`).

--- a/packages/framework-vue3/src/framework-preset-vue3.test.ts
+++ b/packages/framework-vue3/src/framework-preset-vue3.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, rs } from '@rstest/core'
+import { logger } from 'storybook/internal/node-logger'
+import { rsbuildFinal } from './framework-preset-vue3'
+import type { FrameworkOptions } from './types'
+
+type RsbuildFinalOptions = Parameters<NonNullable<typeof rsbuildFinal>>[1]
+
+const createOptions = (docgen?: FrameworkOptions['docgen']) =>
+  ({
+    presets: {
+      apply: async (name: string) => {
+        if (name === 'frameworkOptions') {
+          return docgen === undefined ? {} : { docgen }
+        }
+        return undefined
+      },
+    },
+    presetsList: [],
+  }) as unknown as RsbuildFinalOptions
+
+describe('rsbuildFinal', () => {
+  it('does not inject the Vue docgen loader when docgen is false', async () => {
+    const config = await rsbuildFinal!({}, createOptions(false))
+
+    expect(config.tools?.rspack).toBeUndefined()
+  })
+
+  it.each([undefined, true])(
+    'injects the Vue docgen loader when docgen is %s',
+    async (docgen) => {
+      const config = await rsbuildFinal!({}, createOptions(docgen))
+
+      expect(config.tools?.rspack).toEqual(expect.any(Function))
+    },
+  )
+
+  it.each([
+    ['string selector', 'vue-component-meta'],
+    [
+      'plugin config',
+      { plugin: 'vue-component-meta', tsconfig: 'tsconfig.app.json' },
+    ],
+  ] as const)(
+    'warns and falls back to vue-docgen-api for a vue-component-meta %s',
+    async (_selector, docgen) => {
+      const warn = rs.spyOn(logger, 'warn').mockImplementation(() => {})
+
+      const config = await rsbuildFinal!({}, createOptions(docgen))
+
+      expect(warn).toHaveBeenCalledWith(
+        'vue-component-meta is not yet supported by storybook-rsbuild; falling back to vue-docgen-api.',
+      )
+      expect(config.tools?.rspack).toEqual(expect.any(Function))
+    },
+  )
+})

--- a/packages/framework-vue3/src/framework-preset-vue3.ts
+++ b/packages/framework-vue3/src/framework-preset-vue3.ts
@@ -1,10 +1,27 @@
 import { mergeRsbuildConfig, type RsbuildConfig } from '@rsbuild/core'
-import type { StorybookConfig } from './types'
+import { logger } from 'storybook/internal/node-logger'
+import type { FrameworkOptions, StorybookConfig } from './types'
 
-const rsbuildFinalDoc: StorybookConfig['rsbuildFinal'] = (
+const rsbuildFinalDoc: StorybookConfig['rsbuildFinal'] = async (
   _config,
   options,
-): RsbuildConfig => {
+): Promise<RsbuildConfig> => {
+  const frameworkOptions = await options.presets.apply<FrameworkOptions | null>(
+    'frameworkOptions',
+  )
+  if (frameworkOptions?.docgen === false) {
+    return {}
+  }
+  if (
+    frameworkOptions?.docgen === 'vue-component-meta' ||
+    (typeof frameworkOptions?.docgen === 'object' &&
+      frameworkOptions.docgen.plugin === 'vue-component-meta')
+  ) {
+    logger.warn(
+      'vue-component-meta is not yet supported by storybook-rsbuild; falling back to vue-docgen-api.',
+    )
+  }
+
   let vueDocgenOptions = {}
 
   for (const preset of options.presetsList || []) {
@@ -59,13 +76,13 @@ const rsbuildFinalBase: StorybookConfig['rsbuildFinal'] = (
   }
 }
 
-export const rsbuildFinal: StorybookConfig['rsbuildFinal'] = (
+export const rsbuildFinal: StorybookConfig['rsbuildFinal'] = async (
   config,
   options,
 ) => {
   return mergeRsbuildConfig(
     config,
     rsbuildFinalBase(config, options),
-    rsbuildFinalDoc(config, options),
+    await rsbuildFinalDoc(config, options),
   )
 }

--- a/packages/framework-vue3/src/types.test.ts
+++ b/packages/framework-vue3/src/types.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from '@rstest/core'
-import type { FrameworkOptions } from './types'
+import type { ComponentDoc } from 'vue-docgen-api'
+import type {
+  FrameworkOptions,
+  VueDocgenInfo,
+  VueDocgenInfoEntry,
+} from './types'
+
+type ArrayElement<T> = T extends readonly (infer TElement)[] ? TElement : never
+
+type Equal<TLeft, TRight> =
+  (<T>() => T extends TLeft ? 1 : 2) extends <T>() => T extends TRight ? 1 : 2
+    ? true
+    : false
 
 const portableDocgenOptions = [
   false,
@@ -12,8 +24,40 @@ const portableDocgenOptions = [
   },
 ] satisfies NonNullable<FrameworkOptions['docgen']>[]
 
+const publicDocgenTypeAssertions: [
+  Equal<VueDocgenInfo<'vue-docgen-api'>, ComponentDoc>,
+  Equal<VueDocgenInfo<'vue-component-meta'>, never>,
+  Equal<
+    VueDocgenInfoEntry<'vue-docgen-api', 'props'>,
+    ArrayElement<ComponentDoc['props']>
+  >,
+  Equal<
+    VueDocgenInfoEntry<'vue-docgen-api', 'events'>,
+    ArrayElement<ComponentDoc['events']>
+  >,
+  Equal<
+    VueDocgenInfoEntry<'vue-docgen-api', 'slots'>,
+    ArrayElement<ComponentDoc['slots']>
+  >,
+  Equal<
+    VueDocgenInfoEntry<'vue-docgen-api', 'expose'>,
+    ArrayElement<ComponentDoc['expose']>
+  >,
+] = [true, true, true, true, true, true]
+
 describe('FrameworkOptions', () => {
   it('accepts portable Vue docgen options', () => {
     expect(portableDocgenOptions).toHaveLength(5)
+  })
+
+  it('exports vue-docgen-api metadata types', () => {
+    expect(publicDocgenTypeAssertions).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+    ])
   })
 })

--- a/packages/framework-vue3/src/types.test.ts
+++ b/packages/framework-vue3/src/types.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@rstest/core'
+import type { FrameworkOptions } from './types'
+
+const portableDocgenOptions = [
+  false,
+  true,
+  'vue-docgen-api',
+  'vue-component-meta',
+  {
+    plugin: 'vue-component-meta',
+    tsconfig: 'tsconfig.app.json',
+  },
+] satisfies NonNullable<FrameworkOptions['docgen']>[]
+
+describe('FrameworkOptions', () => {
+  it('accepts portable Vue docgen options', () => {
+    expect(portableDocgenOptions).toHaveLength(5)
+  })
+})

--- a/packages/framework-vue3/src/types.ts
+++ b/packages/framework-vue3/src/types.ts
@@ -12,8 +12,17 @@ import type {
 type FrameworkName = CompatibleString<'storybook-vue3-rsbuild'>
 type BuilderName = CompatibleString<'storybook-builder-rsbuild'>
 
+export type VueDocgenPlugin = 'vue-docgen-api' | 'vue-component-meta'
+
 export type FrameworkOptions = {
   builder?: BuilderOptions
+  docgen?:
+    | boolean
+    | VueDocgenPlugin
+    | {
+        plugin: 'vue-component-meta'
+        tsconfig: `${string}/tsconfig${string}.json` | `tsconfig${string}.json`
+      }
 }
 
 type StorybookConfigFramework = {

--- a/packages/framework-vue3/src/types.ts
+++ b/packages/framework-vue3/src/types.ts
@@ -8,11 +8,31 @@ import type {
   StorybookConfigRsbuild,
   TypescriptOptions as TypescriptOptionsBuilder,
 } from 'storybook-builder-rsbuild'
+import type { ComponentDoc } from 'vue-docgen-api'
 
 type FrameworkName = CompatibleString<'storybook-vue3-rsbuild'>
 type BuilderName = CompatibleString<'storybook-builder-rsbuild'>
 
 export type VueDocgenPlugin = 'vue-docgen-api' | 'vue-component-meta'
+
+type ArrayElement<T> = T extends readonly (infer TElement)[] ? TElement : never
+
+export type VueDocgenInfo<T extends VueDocgenPlugin> =
+  T extends 'vue-docgen-api' ? ComponentDoc : never
+
+export type VueDocgenInfoEntry<
+  T extends VueDocgenPlugin,
+  TKey extends 'props' | 'events' | 'slots' | 'exposed' | 'expose' =
+    | 'props'
+    | 'events'
+    | 'slots'
+    | 'exposed'
+    | 'expose',
+> = ArrayElement<
+  T extends 'vue-docgen-api'
+    ? VueDocgenInfo<'vue-docgen-api'>[Exclude<TKey, 'exposed'>]
+    : never
+>
 
 export type FrameworkOptions = {
   builder?: BuilderOptions


### PR DESCRIPTION
## Summary

- **V1:** add the portable Vue `docgen` framework option and skip the Rsbuild docgen loader when it is `false`, following [storybookjs/storybook#32319](https://redirect.github.com/storybookjs/storybook/pull/32319)
- **V1:** preserve the current `vue-docgen-api` behavior for unset, `true`, and explicit `vue-docgen-api` selections
- **V3:** export `VueDocgenPlugin`, `VueDocgenInfo`, and `VueDocgenInfoEntry` over `vue-docgen-api`'s `ComponentDoc`, following [storybookjs/storybook#26177](https://redirect.github.com/storybookjs/storybook/pull/26177)
- record the scoped ports and intentional divergences in the Storybook drift manifest

## TDD coverage

- verifies `docgen: false` removes the docgen `tools.rspack` fragment while unset/`true` keep it
- verifies both string and object `vue-component-meta` selectors warn and retain the fallback loader
- compile-asserts the portable framework option shape
- compile-asserts `ComponentDoc` plus `props`, `events`, `slots`, and `expose` entry types

## Intentional deviations

- V2 remains deferred: `vue-component-meta` selectors are accepted for config portability, but warn and fall back to `vue-docgen-api` instead of enabling the unsupported engine
- the public metadata types are declared locally because pinned `@storybook/vue3@10.5.10` does not export them; the deferred `vue-component-meta` metadata branch resolves to `never`
- upstream Vite option/plugin wiring is folded into the existing Rsbuild `rsbuildFinal`/`vue-docgen-loader` integration

## Validation

- `pnpm exec biome check --write packages/framework-vue3/src/framework-preset-vue3.ts packages/framework-vue3/src/framework-preset-vue3.test.ts packages/framework-vue3/src/types.ts packages/framework-vue3/src/types.test.ts .agents/skills/storybook-check/manifest.json`
- `pnpm exec rstest packages/framework-vue3`
- `pnpm check`
- `pnpm --filter storybook-vue3-rsbuild build`
- `pnpm --filter @sandboxes/vue3 build:storybook`
- manifest JSON parse check


## Manual sandbox E2E (docgen option, real framework-option resolution)

Verified both directions against `sandboxes/vue3` with real `storybook build` runs (temporary config, reverted afterwards — not committed, so the sandbox keeps covering the default path):

- **Default (`docgen` unset)**: `pnpm --filter @sandboxes/vue3 exec storybook build --stats-json` — story chunks contain `__docgenInfo` (e.g. `__docgenInfo={exportName:"default",displayName:"Button",...}`), confirming `vue-docgen-loader` is applied through Storybook core's actual option resolution.
- **`framework.options.docgen: false`**: same build succeeds (`Storybook build completed successfully`), all Button/Header/Page story chunks compile, and every story chunk contains **0** `__docgenInfo` occurrences — the loader is genuinely omitted through the real resolution path, not only in the mocked unit tests.
