### PR TITLE
docs: add upstream porting and sync doctrine guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,5 +33,6 @@ Read the matching guide before starting the task:
 - Committing, pushing, or opening/updating a PR → [docs/git-workflow.md](docs/git-workflow.md)
 - Editing dependency manifests or lockfiles, or after a `rebase` / `merge` / `stash pop` → [docs/dependencies.md](docs/dependencies.md)
 - Writing/running tests, sandboxes, or e2e → [docs/testing.md](docs/testing.md)
+- Porting or syncing code from upstream `storybookjs/storybook`, or acting on a sync/check report → [docs/upstream-port.md](docs/upstream-port.md)
 - Releasing/publishing → [docs/release.md](docs/release.md)
 - Repo layout, package `exports` / `build-config.ts`, or touching anything under `packages/*/src` → [docs/project-structure.md](docs/project-structure.md)

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -22,4 +22,4 @@
 - **File set changes** — adding, renaming, moving, or deleting a file in those trees needs a `mappings` entry or a `localOnlyFiles` entry.
 - **Content changes** — editing a mapped file so it deliberately departs from its upstream counterpart needs a line in that mapping's `intentionalDivergences` saying why. The audit diffs file contents, so an undocumented divergence is indistinguishable from a bug; no lint or check command catches it.
 
-Tests, `.stories.`, `.d.ts`, `__tests__/`, `__fixtures__/`, and `__mocks__/` files are exempt.
+Tests, `.stories.`, `.d.ts`, `__tests__/`, `__fixtures__/`, and `__mocks__/` files are exempt. The porting doctrine itself lives in [upstream-port.md](upstream-port.md).

--- a/docs/upstream-port.md
+++ b/docs/upstream-port.md
@@ -4,7 +4,7 @@ This repo adapts upstream `storybookjs/storybook` (mainly `builder-webpack5`, wi
 
 ## Doctrine: pure port
 
-- Follow upstream behavior — implementation, naming, semantics, and dependency choices are copied from upstream; only Rsbuild/Rspack-mandated mechanical adaptation is allowed. Mirror upstream's structure 1:1 even when it duplicates logic locally; staying literally identical reduces noise in every future drift comparison.
+- Follow upstream behavior — implementation, naming, semantics, and the dependency set are copied from upstream; only Rsbuild/Rspack-mandated mechanical adaptation is allowed. Mirror upstream's structure 1:1 even when it duplicates logic locally; staying literally identical reduces noise in every future drift comparison. Dependency **classification** follows the local bundle-vs-external contract, not upstream's placement — check `getExternal` before adopting it (see [dependencies.md](dependencies.md)).
 - Port upstream's **intent**, not lines, in two cases: a capability upstream implemented only on the Vite side (port the Vite semantics onto Rsbuild APIs), and an upstream implementation that is broken under the current core (port the intent, record the deviation).
 - A perceived upstream bug or better approach is reported to the user, never implemented unilaterally. Deviating needs the user's explicit approval, presented as a binary choice (upstream-literal vs. local variant).
 - Every approved deviation is recorded twice, in the same change: an `intentionalDivergences` line in the manifest (see [project-structure.md](project-structure.md)), and an in-code comment on exactly the lines a future sync would silently revert. Comments in ported code cite an upstream permalink instead of copying upstream's own comment text.
@@ -13,7 +13,7 @@ This repo adapts upstream `storybookjs/storybook` (mainly `builder-webpack5`, wi
 
 ## Porting a change
 
-- Port every file the upstream change touches, together with follow-up commits already folded into upstream's current state — a partial port is a defect.
+- Port every touched file that has a mapped or same-purpose local counterpart (plus the tests covering the behavior), together with follow-up commits already folded into upstream's current state — porting only part of the counterpart set is a defect. Upstream-only files (docs, CI/tooling, `storybook/internal/*`) stay out, per the sync skill's skip rules.
 - Verify against the **current** upstream source on `next`, never against the referenced upstream PR (the PR may be stale). `next` is the reference for verification and drift detection; a Storybook **release** is the trigger for adopting a capability that is unreleased or unstable — a port blocked on an unreleased upstream API is implemented and parked as a green draft PR naming the unblock signal, not reimplemented around the block.
 - Never copy an upstream config value or version gate bare: port the preconditions that make the value valid, and translate webpack-version conditions into their rspack equivalents.
 - Work upstream did not do (restructuring sandboxes, fixing pre-existing behavior that matches upstream) is out of scope for a port PR.

--- a/docs/upstream-port.md
+++ b/docs/upstream-port.md
@@ -1,0 +1,27 @@
+# Upstream Porting & Sync
+
+This repo adapts upstream `storybookjs/storybook` (mainly `builder-webpack5`, with `builder-vite` as a second reference) onto Rsbuild. Tracking runs on two skills: `storybook-sync` (incremental commit triage) and `storybook-check` (stateless full-content drift audit) — their mechanics live in `.agents/skills/storybook-{sync,check}/SKILL.md`. This guide carries the porting doctrine.
+
+## Doctrine: pure port
+
+- Follow upstream behavior — implementation, naming, semantics, and dependency choices are copied from upstream; only Rsbuild/Rspack-mandated mechanical adaptation is allowed. Mirror upstream's structure 1:1 even when it duplicates logic locally; staying literally identical reduces noise in every future drift comparison.
+- Port upstream's **intent**, not lines, in two cases: a capability upstream implemented only on the Vite side (port the Vite semantics onto Rsbuild APIs), and an upstream implementation that is broken under the current core (port the intent, record the deviation).
+- A perceived upstream bug or better approach is reported to the user, never implemented unilaterally. Deviating needs the user's explicit approval, presented as a binary choice (upstream-literal vs. local variant).
+- Every approved deviation is recorded twice, in the same change: an `intentionalDivergences` line in the manifest (see [project-structure.md](project-structure.md)), and an in-code comment on exactly the lines a future sync would silently revert. Comments in ported code cite an upstream permalink instead of copying upstream's own comment text.
+- Both upstream builders count as precedent: a divergence from `builder-webpack5` is not a divergence if `builder-vite` does it.
+- `templates/preview.ejs` stays verbatim-aligned with upstream `builder-webpack5`; no new divergence in it.
+
+## Porting a change
+
+- Port every file the upstream change touches, together with follow-up commits already folded into upstream's current state — a partial port is a defect.
+- Verify against the **current** upstream source on `next`, never against the referenced upstream PR (the PR may be stale). `next` is the reference for verification and drift detection; a Storybook **release** is the trigger for adopting a capability that is unreleased or unstable — a port blocked on an unreleased upstream API is implemented and parked as a green draft PR naming the unblock signal, not reimplemented around the block.
+- Never copy an upstream config value or version gate bare: port the preconditions that make the value valid, and translate webpack-version conditions into their rspack equivalents.
+- Work upstream did not do (restructuring sandboxes, fixing pre-existing behavior that matches upstream) is out of scope for a port PR.
+- One upstream cluster per branch/PR, cut from latest `origin/main` and rebased before push — never stacked on an unmerged branch. The PR cites the originating upstream PRs (`redirect.github.com` links) and declares any unportable parts. Manifest updates ride in the port PR, never as a separate PR.
+
+## Triage & interaction rules
+
+- Before accepting a reported behavior as this repo's bug, read how the upstream builders implement the same logic. Behavior aligned with upstream is not this repo's bug; a defect that reproduces identically upstream is left in place — with a TODO at the port site stating the tracked upstream fix and the correct alternative — not fixed as a silent divergence.
+- Never act proactively on the upstream repository: no issues, no PRs, no reporting locally-found bugs upstream.
+- Review-bot feedback that would cause divergence from upstream is declined in-thread ("faithful port of upstream <commit>"); only a genuinely serious finding (real bug, security, build failure) is an exception, and it is escalated to the user.
+- Sync/port PRs are never self-merged — the merge decision is the user's.


### PR DESCRIPTION
## What

Adds `docs/upstream-port.md` — the porting doctrine for code adapted from upstream `storybookjs/storybook` — and routes it from the root `AGENTS.md` topic-guide table.

The guide distills the standing policy applied across past porting and sync work:

- **Pure port doctrine**: follow upstream implementation, naming, semantics, and structure 1:1; only Rsbuild/Rspack-mandated adaptation. Deviations require an explicit user decision and are recorded twice in the same change — `intentionalDivergences` in the manifest plus an in-code comment at the divergence site.
- **Porting workflow**: port every touched file together; verify against current upstream `next` (not the referenced PR); `next` is for verification, a release gates adoption of unreleased APIs (blocked ports park as draft PRs); never copy config values or version gates without their preconditions; one upstream cluster per branch/PR, manifest updates ride along.
- **Triage & interaction**: behavior aligned with upstream is not this repo's bug and upstream-inherited defects are tracked via TODO rather than silently diverged; never act proactively on the upstream repository; review-bot feedback that would cause divergence is declined as a faithful port; sync/port PRs are never self-merged.

Mechanics of the two tracking skills stay in `.agents/skills/storybook-{sync,check}/SKILL.md`; this guide carries only the doctrine.

## Validation

- Docs-only diff; all links resolve.