### PR TITLE
docs(modernjs): install the configured framework

### DIFF
--- a/website/docs/en/guide/integrations/modernjs.mdx
+++ b/website/docs/en/guide/integrations/modernjs.mdx
@@ -10,9 +10,9 @@ Explore the [Modern.js React example](https://github.com/rstackjs/storybook-rsbu
 
 ### Installation
 
-<PackageManagerTabs command="install @rsbuild/core storybook-builder-rsbuild storybook-addon-modernjs -D" />
+<PackageManagerTabs command="install @rsbuild/core storybook-react-rsbuild storybook-addon-modernjs -D" />
 
-Install `@rsbuild/core` in the same workspace. Without it, the addon cannot read your Modern.js configuration.
+Install the React framework package and `@rsbuild/core` in the same workspace. `storybook-react-rsbuild` provides the framework named in the configuration below, while `@rsbuild/core` lets the addon read your Modern.js configuration.
 
 Match the version used by `@modern-js/app-tools` when possible. If you install a different release, `storybook-addon-modernjs` prints a warning with the recommended version.
 
@@ -25,7 +25,7 @@ import type { StorybookConfig } from 'storybook-react-rsbuild'
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['storybook-addon-modernjs'],
-  framework: ['storybook-react-rsbuild'],
+  framework: 'storybook-react-rsbuild',
 }
 export default config
 ```
@@ -63,7 +63,7 @@ const config: StorybookConfig = {
       },
     },
   ],
-  framework: ['storybook-react-rsbuild'],
+  framework: 'storybook-react-rsbuild',
 }
 export default config
 ```

--- a/website/docs/zh/guide/integrations/modernjs.mdx
+++ b/website/docs/zh/guide/integrations/modernjs.mdx
@@ -10,9 +10,9 @@ import { PackageManagerTabs } from '@theme'
 
 ### 安装
 
-<PackageManagerTabs command="install @rsbuild/core storybook-builder-rsbuild storybook-addon-modernjs -D" />
+<PackageManagerTabs command="install @rsbuild/core storybook-react-rsbuild storybook-addon-modernjs -D" />
 
-请在同一个 workspace 中安装 `@rsbuild/core`。否则该 addon 无法读取你的 Modern.js 配置。
+请在同一个 workspace 中安装 React framework 包和 `@rsbuild/core`。下面配置中使用的 `storybook-react-rsbuild` 提供所需的 framework，`@rsbuild/core` 让 addon 能够读取你的 Modern.js 配置。
 
 请尽量与 `@modern-js/app-tools` 所使用的版本保持一致。如果你安装了不同的版本，`storybook-addon-modernjs` 会打印一条警告并给出推荐版本。
 
@@ -25,7 +25,7 @@ import type { StorybookConfig } from 'storybook-react-rsbuild'
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['storybook-addon-modernjs'],
-  framework: ['storybook-react-rsbuild'],
+  framework: 'storybook-react-rsbuild',
 }
 export default config
 ```
@@ -63,7 +63,7 @@ const config: StorybookConfig = {
       },
     },
   ],
-  framework: ['storybook-react-rsbuild'],
+  framework: 'storybook-react-rsbuild',
 }
 export default config
 ```


### PR DESCRIPTION
The Modern.js guide now installs storybook-react-rsbuild, which the examples configure, and uses the framework string form accepted by StorybookConfig in both locale docs.\n\nValidated with pnpm --filter website build and git diff --check.